### PR TITLE
[FIX][narun] 편지함 폴더, 프롬 분리

### DIFF
--- a/src/components/letterBox/letterCard/LetterCardCompact.tsx
+++ b/src/components/letterBox/letterCard/LetterCardCompact.tsx
@@ -10,13 +10,13 @@ type LetterCardCompactProps = {
 export default function LetterCardCompact({ content, fromName }: LetterCardCompactProps) {
   return (
     <div className="w-full h-[46px] rounded-lg bg-white px-3 py-2 flex items-center justify-between">
-      <div className="flex items-center gap-[12px] flex-1">
+      <div className="flex items-center gap-[12px] flex-1 min-w-0">
         <img src={roundIcon} alt="round-icon" />
-        <p className="text-[14px] font-medium text-[#555557] line-clamp-1">{content}</p>
+        <p className="text-[14px] font-medium text-[#555557] truncate">{content}</p>
       </div>
 
-      <div className="flex h-5 w-[45px] items-center justify-center rounded-[6px]">
-        <p className="text-[12px] text-[#9D9D9F] truncate">{fromName}</p>
+      <div className="flex h-5 w-[45px] min-w-0 items-center justify-center rounded-[6px]">
+        <p className="text-[12px] text-[#9D9D9F] truncate w-full text-center">{fromName}</p>
       </div>
     </div>
   );

--- a/src/pages/letter/LetterBoxPage.tsx
+++ b/src/pages/letter/LetterBoxPage.tsx
@@ -57,10 +57,23 @@ export default function LetterBoxPage() {
 
   useEffect(() => {
     const run = async () => {
-      const [folderData, fromData] = await Promise.all([getFolderList(), getFromList()]);
-      setFolders([...folderData].sort((a, b) => a.folderOrder - b.folderOrder));
-      setAllFroms(fromData);
+      try {
+        const folderData = await getFolderList();
+        setFolders([...folderData].sort((a, b) => a.folderOrder - b.folderOrder));
+      } catch (e) {
+        console.error('getFolderList failed', e);
+        setFolders([]);
+      }
+
+      try {
+        const fromData = await getFromList();
+        setAllFroms(fromData);
+      } catch (e) {
+        console.error('getFromList failed', e);
+        setAllFroms([]);
+      }
     };
+
     void run();
   }, []);
 


### PR DESCRIPTION
## #️⃣ 관련 이슈
- close #87

---

## 📝 작업 요약
기존에 Promise.all 로 from, folder을 동시 요청 했던 걸 분리했습니다

---

## 🔧 변경 사항
- 마이페이지 UI 구현
- 사용자 정보 표시 로직 추가
- 버튼 및 인터랙션 처리

---

## 💬 리뷰어 참고 사항
리뷰 시 참고하면 좋을 점이나 고민했던 부분이 있다면 작성해주세요.

---

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [x] 로컬에서 정상 동작을 확인했습니다.
- [x] UI 변경 사항을 직접 확인했습니다.
- [x] 불필요한 console.log를 제거했습니다.
- [ ] 관련 이슈를 연결했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 폴더 목록과 발신자 목록 로드가 서로 영향을 주지 않도록 독립적으로 처리되어 데이터 로딩 안정성이 향상되었습니다.
* **UI 개선**
  * 콤팩트 편지 카드의 레이아웃·정렬과 텍스트 처리(오버플로우 생략)가 개선되어 표시가 더 깔끔해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->