### PR TITLE
[FIX][narun] 이미지 업로드 문제 수정

### DIFF
--- a/src/api/upload.ts
+++ b/src/api/upload.ts
@@ -2,6 +2,7 @@
 
 import { api } from './http';
 import type { UploadImageResponse } from '@/types/upload';
+import { compressImage, pickUploadPolicy } from '@/utils/image';
 
 export const normalizeImageUrl = (url: string): string => {
   if (!url) return url;
@@ -9,8 +10,10 @@ export const normalizeImageUrl = (url: string): string => {
   // 앞뒤 공백 및 쌍따옴표 제거
   let cleaned = url.trim().replace(/^"|"$/g, '');
 
+  // 이미 절대경로면 그대로 반환
   if (cleaned.startsWith('http://') || cleaned.startsWith('https://')) return cleaned;
 
+  // CloudFront 도메인 치환
   return cleaned.replace('${AWS_CLOUDFRONT_DOMAIN}', import.meta.env.VITE_CLOUDFRONT_BASE);
 };
 
@@ -18,11 +21,23 @@ export const uploadImage = async (
   file: File,
   dir: 'profile' | 'letter' | 'sticker' | 'folder'
 ): Promise<UploadImageResponse> => {
+  // 업로드 정책 (dir에 따라 리사이즈 크기/품질 다르게 적용)
+  const { maxSide, quality } = pickUploadPolicy(dir);
+
+  // 이미지 파일 2MB 초과일 경우 압축 후 업로드
+  const fileToUpload =
+    file.type.startsWith('image/') && file.size > 2_000_000
+      ? await compressImage(file, maxSide, quality)
+      : file;
+
   const formData = new FormData();
-  formData.append('file', file);
+  formData.append('file', fileToUpload);
   formData.append('dir', dir);
 
-  const { data } = await api.post<UploadImageResponse>('/images', formData);
+  const { data } = await api.post<UploadImageResponse>('/images', formData, {
+    timeout: 60000, // 모바일 대용량 업로드 대비
+    headers: { 'Content-Type': 'multipart/form-data' },
+  });
 
   if (data?.data?.url) {
     data.data.url = normalizeImageUrl(data.data.url);

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -1,0 +1,39 @@
+export const pickUploadPolicy = (dir: 'profile' | 'letter' | 'sticker' | 'folder') => {
+  if (dir === 'profile') return { maxSide: 1024, quality: 0.85 };
+  if (dir === 'sticker') return { maxSide: 1024, quality: 0.85 };
+  if (dir === 'letter') return { maxSide: 1600, quality: 0.85 };
+  return { maxSide: 1600, quality: 0.85 };
+};
+
+export const compressImage = async (file: File, maxSide: number, quality: number) => {
+  const bitmap = await createImageBitmap(file);
+
+  const w = bitmap.width;
+  const h = bitmap.height;
+  const m = Math.max(w, h);
+  const scale = m > maxSide ? maxSide / m : 1;
+
+  const canvas = document.createElement('canvas');
+  canvas.width = Math.round(w * scale);
+  canvas.height = Math.round(h * scale);
+
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('canvas context null');
+
+  ctx.drawImage(bitmap, 0, 0, canvas.width, canvas.height);
+
+  const isPng = file.type === 'image/png';
+  const outType = isPng ? 'image/png' : 'image/jpeg';
+
+  const blob = await new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob(
+      (b) => (b ? resolve(b) : reject(new Error('toBlob returned null'))),
+      outType,
+      isPng ? undefined : quality
+    );
+  });
+
+  const nextName = isPng ? file.name : file.name.replace(/\.\w+$/, '.jpg');
+
+  return new File([blob], nextName, { type: outType });
+};


### PR DESCRIPTION
## #️⃣ 관련 이슈
- close #89

---

## 📝 작업 요약
이미지 용량 초과 시 이미지 압축 후 업로드 하는 것으로 변경했습니다!

---

## 🔧 변경 사항
- 마이페이지 UI 구현
- 사용자 정보 표시 로직 추가
- 버튼 및 인터랙션 처리

---

## 💬 리뷰어 참고 사항
리뷰 시 참고하면 좋을 점이나 고민했던 부분이 있다면 작성해주세요.

---

## ✅ 체크리스트
- [ ] 커밋 메시지 컨벤션을 준수했습니다.
- [ ] 로컬에서 정상 동작을 확인했습니다.
- [ ] UI 변경 사항을 직접 확인했습니다.
- [ ] 불필요한 console.log를 제거했습니다.
- [ ] 관련 이슈를 연결했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신규 기능**
  * 이미지 자동 압축: 2MB 이상의 이미지 파일은 업로드 시 자동으로 압축됩니다.
  * 디렉토리별 최적화: 프로필, 레터, 스티커, 폴더 등 위치에 따라 최적화된 압축 설정을 적용합니다.

* **개선**
  * 업로드 안정성 강화: 이미지 업로드 타임아웃을 60초로 연장하여 더욱 안정적인 업로드 환경을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->