### PR TITLE
[FIX][sami] 캡처 해상도 올리기 및 이미지 중복 체크

### DIFF
--- a/src/components/create/ImageUploadButton.tsx
+++ b/src/components/create/ImageUploadButton.tsx
@@ -1,19 +1,57 @@
 import { useRef } from "react";
+import useToast from "@/hooks/useToast";
 
 interface Props {
   images: File[];
   setImages: React.Dispatch<React.SetStateAction<File[]>>;
 }
 
-export default function ImageUploadButton({ images, setImages }: Props) {
+export default function ImageUploadButton({ setImages }: Props) {
   const inputRef = useRef<HTMLInputElement>(null);
+  const toast = useToast();
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (!e.target.files) return;
 
     const files = Array.from(e.target.files);
-    const remain = 10 - images.length;
-    setImages((prev) => [...prev, ...files.slice(0, remain)]);
+
+    setImages((prev) => {
+      const remain = 10 - prev.length;
+      if (remain <= 0) {
+        toast.show("이미지는 최대 10장까지 업로드할 수 있어요.");
+        return prev;
+      }
+
+      const existingKeySet = new Set(
+        prev.map((f) => `${f.name}_${f.size}_${f.lastModified}`)
+      );
+
+      const uniqueNewFiles: File[] = [];
+      let hasDuplicate = false;
+
+      for (const file of files) {
+        const key = `${file.name}_${file.size}_${file.lastModified}`;
+        if (existingKeySet.has(key)) {
+          hasDuplicate = true;
+          continue;
+        }
+        existingKeySet.add(key);
+        uniqueNewFiles.push(file);
+      }
+
+      if (hasDuplicate) {
+        toast.show("중복된 이미지입니다.");
+      }
+
+      if (uniqueNewFiles.length === 0) {
+        return prev;
+      }
+
+      return [...prev, ...uniqueNewFiles.slice(0, remain)];
+    });
+
+    // 같은 파일 다시 선택할 수 있도록 input 초기화
+    e.target.value = "";
   };
 
   return (

--- a/src/components/letter/LetterDetailSection.tsx
+++ b/src/components/letter/LetterDetailSection.tsx
@@ -132,9 +132,12 @@ export default function LetterDetailSection({
     const el = cardRef.current;
     if (!el) return;
 
+    const devicePixelRatio = window.devicePixelRatio || 1;
+    const captureScale = Math.min(3, devicePixelRatio);
+
     const originalCanvas = await html2canvas(el, {
       backgroundColor: "#ffffff",
-      scale: Math.min(2, window.devicePixelRatio || 1),
+      scale: captureScale,
       useCORS: true,
       onclone: (doc) => {
         const clonedEl = doc.querySelector(

--- a/src/pages/create/CreateDetailPage.tsx
+++ b/src/pages/create/CreateDetailPage.tsx
@@ -107,13 +107,15 @@ export default function CreateDetailPage() {
           const receivedAt = payload.unknownDate ? "" : payload.date ?? "";
           const finalContent = payload.content ?? content;
 
+          const uniqueImageIds = Array.from(new Set(state.imageIds ?? []));
+
           const letterRes = await createLetterMutation.mutateAsync({
             content: finalContent,
             aiSummary: state.aiResult.summary,
             emotionIds: state.aiResult.emotions.map((e) => e.emotionId),
             fromId,
             receivedAt,
-            imageIds: state.imageIds ?? [],
+            imageIds: uniqueImageIds,
           });
 
           if (!letterRes.success) {

--- a/src/pages/create/LetterCreatePage.tsx
+++ b/src/pages/create/LetterCreatePage.tsx
@@ -44,7 +44,9 @@ export default function LetterCreatePage() {
           images.map((file) => uploadImage(file, "letter"))
         );
         uploadedImageUrls = uploadResults.map((res) => res.data.url);
-        uploadedImageIds = uploadResults.map((res) => res.data.imageId);
+        uploadedImageIds = Array.from(
+          new Set(uploadResults.map((res) => res.data.imageId))
+        );
 
         // 2. OCR -> text 변환
         const ocrResponse = await runOcr(uploadedImageIds);


### PR DESCRIPTION
## #️⃣ 관련 이슈
- close #91 

---

## 📝 작업 요약
캡처 해상도 올리기 및 이미지 중복 체크 토스트 알림 띄우기

---

## 🔧 변경 사항

---

## 💬 리뷰어 참고 사항
리뷰 시 참고하면 좋을 점이나 고민했던 부분이 있다면 작성해주세요.

---

## ✅ 체크리스트
- [X] 커밋 메시지 컨벤션을 준수했습니다.
- [X] 로컬에서 정상 동작을 확인했습니다.
- [X] UI 변경 사항을 직접 확인했습니다.
- [X] 불필요한 console.log를 제거했습니다.
- [X] 관련 이슈를 연결했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 이미지 업로드 시 최대 10개까지만 추가 가능하도록 제한
  * 중복된 이미지 자동 감지 및 필터링
  * 사용자 피드백을 위한 알림 메시지 추가

* **개선 사항**
  * 고해상도 디스플레이에서 이미지 렌더링 품질 향상
  * 중복 이미지 ID 자동 제거로 데이터 무결성 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->