### PR TITLE
[FIX][sami] html2canvas 하트 버튼 path 기반 컴포넌트로 교체

### DIFF
--- a/src/components/icons/HeartFilledIcon.tsx
+++ b/src/components/icons/HeartFilledIcon.tsx
@@ -1,0 +1,25 @@
+import type React from "react";
+
+export type HeartFilledIconProps = React.SVGProps<SVGSVGElement>;
+
+export default function HeartFilledIcon(props: HeartFilledIconProps) {
+  return (
+    <svg
+      width="14"
+      height="13"
+      viewBox="0 0 15 14"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path
+        d="M7.09961 2.8501C7.09961 2.8501 7.14886 3.07347 6.55072 2.1001C5.91517 1.2301 4.97628 0.600098 3.84961 0.600098C2.05128 0.600098 0.599609 2.1076 0.599609 3.9751C0.599609 4.6726 0.801832 5.3176 1.1485 5.8501C1.7335 6.7576 7.09961 12.6001 7.09961 12.6001M7.09961 2.8501C7.09961 2.8501 7.09961 2.8501 7.6485 2.1001C8.28405 1.2301 9.22294 0.600098 10.3496 0.600098C12.1479 0.600098 13.5996 2.1076 13.5996 3.9751C13.5996 4.6726 13.3974 5.3176 13.0507 5.8501C12.4657 6.7576 7.09961 12.6001 7.09961 12.6001"
+        fill="#FF5F2F"
+        stroke="#FF5F2F"
+        strokeWidth="1.2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/src/components/icons/HeartOutlineIcon.tsx
+++ b/src/components/icons/HeartOutlineIcon.tsx
@@ -1,0 +1,23 @@
+import type React from "react";
+
+export type HeartOutlineIconProps = React.SVGProps<SVGSVGElement>;
+
+export default function HeartOutlineIcon(props: HeartOutlineIconProps) {
+  return (
+    <svg
+      width="14"
+      height="13"
+      viewBox="0 0 15 14"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path
+        d="M7 2.75C7 2.75 7.04925 2.97338 6.45111 2C5.81556 1.13 4.87667 0.5 3.75 0.5C1.95167 0.5 0.5 2.0075 0.5 3.875C0.5 4.5725 0.702222 5.2175 1.04889 5.75C1.63389 6.6575 7 12.5 7 12.5M7 2.75C7 2.75 7 2.75 7.54889 2C8.18444 1.13 9.12333 0.5 10.25 0.5C12.0483 0.5 13.5 2.0075 13.5 3.875C13.5 4.5725 13.2978 5.2175 12.9511 5.75C12.3661 6.6575 7 12.5 7 12.5"
+        stroke="#FF5F2F"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/src/components/letter/LetterDetailSection.tsx
+++ b/src/components/letter/LetterDetailSection.tsx
@@ -11,8 +11,8 @@ import LetterDetailBottomSheet from "./LetterDetailBottomSheet";
 import aiSummary from "@/assets/create/ai-summary.svg";
 import upBar from "@/assets/letter/up-bar.svg";
 import downBar from "@/assets/letter/down-bar.svg";
-import heartOutlineIcon from "@/assets/letterPage/heart-outline.svg";
-import heartFillIcon from "@/assets/letterPage/heart-filled.svg";
+import HeartFilledIcon from "@/components/icons/HeartFilledIcon";
+import HeartOutlineIcon from "@/components/icons/HeartOutlineIcon";
 import html2canvas from "html2canvas";
 import type { AnalyzeLetterResponse } from "@/types/create";
 import { useFolderList } from "@/hooks/queries/useFolderList";
@@ -280,15 +280,15 @@ export default function LetterDetailSection({
                   setLikeLoading(false);
                 }
               }}
-              className="w-[13px] h-4 mr-1 cursor-pointer"
+              className="w-[13px] h-4 cursor-pointer"
               aria-pressed={liked}
               disabled={likeLoading || toggleLikeMutation.isPending}
             >
-              <img
-                src={liked ? heartFillIcon : heartOutlineIcon}
-                alt="like"
-                className="w-[13px] h-[12px]"
-              />
+              {liked ? (
+                <HeartFilledIcon className="w-[14px] h-[15px]" />
+              ) : (
+                <HeartOutlineIcon className="w-[14px] h-[15px]" />
+              )}
             </button>
         </div>
 

--- a/src/components/letterBox/letterCard/LetterCardDefault.tsx
+++ b/src/components/letterBox/letterCard/LetterCardDefault.tsx
@@ -1,9 +1,9 @@
-import heartOutlineIcon from '@/assets/letterPage/heart-outline.svg';
-import heartFillIcon from '@/assets/letterPage/heart-filled.svg';
 import { useEffect, useRef, useState, type MouseEvent } from 'react';
 import { useToggleLetterLike } from '@/hooks/mutations/useToggleLetterLike';
 import { FromBadge } from '@/components/common/FromBadge';
 import type { From } from '@/types/from';
+import HeartFilledIcon from '@/components/icons/HeartFilledIcon';
+import HeartOutlineIcon from '@/components/icons/HeartOutlineIcon';
 
 type LetterCardDefaultProps = {
   letterId: number;
@@ -72,7 +72,11 @@ export default function LetterCardDefault({
             disabled={toggleLike.isPending}
             className="w-[13px] h-4 cursor-pointer disabled:opacity-50"
           >
-            <img src={liked ? heartFillIcon : heartOutlineIcon} alt="heart-icon" />
+            {liked ? (
+              <HeartFilledIcon className="w-[14px] h-[15px]" />
+            ) : (
+              <HeartOutlineIcon className="w-[14px] h-[15px]" />
+            )}
           </button>
         </div>
 


### PR DESCRIPTION
## #️⃣ 관련 이슈
- close #95 

---

## 📝 작업 요약
html2canvas 하트 버튼 path 기반 컴포넌트로 교체해서 모바일 환경에서 캡처 시 깨지지 않게 수정했습니다.

---

## 🔧 변경 사항

---

## 💬 리뷰어 참고 사항

---

## ✅ 체크리스트
- [X] 커밋 메시지 컨벤션을 준수했습니다.
- [X] 로컬에서 정상 동작을 확인했습니다.
- [X] UI 변경 사항을 직접 확인했습니다.
- [X] 불필요한 console.log를 제거했습니다.
- [X] 관련 이슈를 연결했습니다.
