### PR TITLE
[REFACTOR][sami] 편지 상세, 폴더 목록 불러오기 staletime 짧게

### DIFF
--- a/src/hooks/mutations/useLetterFolder.ts
+++ b/src/hooks/mutations/useLetterFolder.ts
@@ -15,6 +15,7 @@ export function useLetterFolder(letterId: number) {
         return;
       }
       queryClient.invalidateQueries({ queryKey: ["letter", letterId] });
+      queryClient.invalidateQueries({ queryKey: ["folders"] });
     },
     onError: () => {
       toast.show("폴더에 추가하지 못했어요.");
@@ -29,6 +30,7 @@ export function useLetterFolder(letterId: number) {
         return;
       }
       queryClient.invalidateQueries({ queryKey: ["letter", letterId] });
+      queryClient.invalidateQueries({ queryKey: ["folders"] });
     },
     onError: () => {
       toast.show("폴더에서 삭제하지 못했어요.");

--- a/src/hooks/queries/useFolderList.ts
+++ b/src/hooks/queries/useFolderList.ts
@@ -8,7 +8,7 @@ export function useFolderList() {
   return useQuery<Folder[]>({
     queryKey: ['folders'],
     queryFn: getFolderList,
-    staleTime: Infinity,
+    staleTime: 0,
     refetchOnWindowFocus: false,
   });
 }

--- a/src/hooks/queries/useLetterDetail.ts
+++ b/src/hooks/queries/useLetterDetail.ts
@@ -7,7 +7,7 @@ export function useLetterDetail(letterId: number) {
     queryFn: () => getLetterDetail(letterId),
     enabled: Number.isFinite(letterId),
     retry: false,
-    staleTime: 1000 * 60 * 5,
+    staleTime: 0,
     refetchOnWindowFocus: false,
   });
 }


### PR DESCRIPTION
## #️⃣ 관련 이슈
- close #131 

---

## 📝 작업 요약
이번 PR에서 수행한 작업을 간단히 설명해주세요.

---

## 🔧 변경 사항
- 마이페이지 UI 구현
- 사용자 정보 표시 로직 추가
- 버튼 및 인터랙션 처리

---

## 💬 리뷰어 참고 사항
리뷰 시 참고하면 좋을 점이나 고민했던 부분이 있다면 작성해주세요.

---

## ✅ 체크리스트
- [X] 커밋 메시지 컨벤션을 준수했습니다.
- [X] 로컬에서 정상 동작을 확인했습니다.
- [X] UI 변경 사항을 직접 확인했습니다.
- [X] 불필요한 console.log를 제거했습니다.
- [X] 관련 이슈를 연결했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 폴더에서 편지를 추가하거나 제거할 때 폴더 목록이 자동으로 새로고침되어 데이터 일관성이 향상됩니다.
  * 폴더 목록과 편지 세부 정보가 더 자주 업데이트되어 사용자가 항상 최신 정보를 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->