### PR TITLE
[FEAT][narun] 편지함 반응형 구현

### DIFF
--- a/src/components/common/ConfirmModal.tsx
+++ b/src/components/common/ConfirmModal.tsx
@@ -23,14 +23,12 @@ export default function ConfirmModal({
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
-      <div className="relative flex w-[393px] min-h-screen items-center justify-center bg-black/40">
+      <div className="relative flex w-full max-w-[440px] min-h-screen items-center justify-center bg-black/40">
         <div className="w-[294px] rounded-[17px] bg-white px-[18px] pt-[26px] pb-[20px]">
           <div className="flex flex-col gap-[20px]">
             <div className="flex flex-col items-center gap-2">
               <p
-                className={`text-center text-base font-semibold ${
-                  titleClassName ?? 'text-black'
-                }`}
+                className={`text-center text-base font-semibold ${titleClassName ?? 'text-black'}`}
               >
                 {title}
               </p>
@@ -40,7 +38,7 @@ export default function ConfirmModal({
                     .split(/\r?\n/)
                     .map((line) => line.trim())
                     .map((line, idx) => (
-                      <p key={idx} className={idx === 0 ? "" : "mt-1"}>
+                      <p key={idx} className={idx === 0 ? '' : 'mt-1'}>
                         {line}
                       </p>
                     ))}

--- a/src/components/common/FromBadge.tsx
+++ b/src/components/common/FromBadge.tsx
@@ -11,11 +11,11 @@ export function FromBadge({ name, bgColor, fontColor, size = 'md' }: FromBadgePr
   const outerClass =
     size === 'sm'
       ? 'inline-flex h-[20px] px-[8px] rounded-[6px]'
-      : 'inline-flex h-[24px] px-[11px] rounded-[6px]';
+      : 'inline-flex px-[12px] py-[5px] rounded-[6px]';
   const textClass =
     size === 'sm'
       ? 'flex items-center text-[12px] font-medium'
-      : 'flex items-center text-[14px] font-medium';
+      : 'flex items-center text-[13px] font-medium';
 
   return (
     <span data-from-badge className={outerClass} style={{ backgroundColor: bgColor }}>

--- a/src/components/header/TopSection.tsx
+++ b/src/components/header/TopSection.tsx
@@ -9,7 +9,7 @@ export default function TopSection({
 }) {
   return (
     <header className="w-full bg-white border-b border-[#E6E7E9] pt-safe-top">
-      <div className="h-[105px] px-4 flex items-center pt-13">
+      <div className="h-[78px] px-4 flex items-end pb-[20px]">
         <div className="w-1/4 min-w-0 flex items-center">{left}</div>
         <div className="w-2/4 min-w-0 flex justify-center items-center">{center}</div>
         <div className="w-1/4 min-w-0 flex justify-end items-center">{right}</div>

--- a/src/components/home/AddLetterButton.tsx
+++ b/src/components/home/AddLetterButton.tsx
@@ -19,7 +19,7 @@ export default function AddLetterButton({ onClick }: AddLetterButtonProps) {
     <button
       type="button"
       onClick={handleClick}
-      className="flex h-[38px] w-[103px] items-start rounded-full bg-black shadow-[0_0_4px_0.5px_rgba(0,0,0,0.15)] cursor-pointer"
+      className="flex h-[38px] w-[103px] items-start rounded-full bg-black shadow-[0_3px_6px_0_rgba(0,0,0,0.12)] cursor-pointer"
     >
       <div className="ml-[13px] mt-[7px] flex h-6 w-[84px] items-center gap-2">
         <p className="text-[14px] font-semibold leading-none text-white whitespace-nowrap">

--- a/src/components/home/LetterCard.tsx
+++ b/src/components/home/LetterCard.tsx
@@ -32,7 +32,7 @@ export default function LetterCard({ letter, isPinned, onPin, onRequestUnpin }: 
   };
 
   return (
-    <div className="relative mt-5 flex w-full min-w-[320px] max-w-[440px] min-h-[97px] items-center rounded-[10px] bg-white shadow-[0_0_4px_0_rgba(0,0,0,0.12)]">
+    <div className="relative mt-5 flex w-full max-w-[440px] min-h-[97px] items-center rounded-[10px] bg-white shadow-[0_0_4px_0_rgba(0,0,0,0.12)]">
       {/* 날짜 뱃지 */}
       <div className="mx-3 flex h-[57px] w-[47px] shrink-0 flex-col items-center justify-center rounded-[10px] bg-[#FF4F181A]">
         <p className="text-[10px] font-medium text-[#FF5F2F]">{letter?.month ?? ''}</p>

--- a/src/components/home/LetterCard.tsx
+++ b/src/components/home/LetterCard.tsx
@@ -32,7 +32,7 @@ export default function LetterCard({ letter, isPinned, onPin, onRequestUnpin }: 
   };
 
   return (
-    <div className="relative mt-5 flex w-full min-w-[320px] max-w-[440px] min-h-[97px] items-center rounded-[10px] bg-white shadow-[0_0_4px_0_rgba(217,217,217,0.5)]">
+    <div className="relative mt-5 flex w-full min-w-[320px] max-w-[440px] min-h-[97px] items-center rounded-[10px] bg-white shadow-[0_0_4px_0_rgba(0,0,0,0.12)]">
       {/* 날짜 뱃지 */}
       <div className="mx-3 flex h-[57px] w-[47px] shrink-0 flex-col items-center justify-center rounded-[10px] bg-[#FF4F181A]">
         <p className="text-[10px] font-medium text-[#FF5F2F]">{letter?.month ?? ''}</p>

--- a/src/components/home/ProfileCard.tsx
+++ b/src/components/home/ProfileCard.tsx
@@ -12,7 +12,7 @@ interface ProfileCardProps {
 
 export default function ProfileCard({ nickname, bio, imgUrl, onClickSettings }: ProfileCardProps) {
   return (
-    <div className="relative flex min-h-[202px] w-full min-w-[320px] max-w-[440px] flex-col items-center rounded-[10px] bg-white shadow-[0_0_4px_0.5px_rgba(0,0,0,0.15)]">
+    <div className="relative flex min-h-[202px] w-full min-w-[320px] max-w-[440px] flex-col items-center rounded-[10px] bg-white shadow-[0_0_4px_0_rgba(0,0,0,0.12)]">
       <button
         type="button"
         onClick={onClickSettings}

--- a/src/components/home/ProfileCard.tsx
+++ b/src/components/home/ProfileCard.tsx
@@ -12,7 +12,7 @@ interface ProfileCardProps {
 
 export default function ProfileCard({ nickname, bio, imgUrl, onClickSettings }: ProfileCardProps) {
   return (
-    <div className="relative flex min-h-[202px] w-full min-w-[320px] max-w-[440px] flex-col items-center rounded-[10px] bg-white shadow-[0_0_4px_0_rgba(0,0,0,0.12)]">
+    <div className="relative flex min-h-[202px] w-full max-w-[440px] flex-col items-center rounded-[10px] bg-white shadow-[0_0_4px_0_rgba(0,0,0,0.12)]">
       <button
         type="button"
         onClick={onClickSettings}

--- a/src/components/home/ProfileCustomSheet.tsx
+++ b/src/components/home/ProfileCustomSheet.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { HexColorPicker } from 'react-colorful';
 import stickerIcon from '@/assets/homePage/stickerIcon.svg';
 import bgIcon from '@/assets/homePage/bgIcon.svg';
@@ -35,6 +35,12 @@ export default function ProfileCustomSheet({
   const [showPicker, setShowPicker] = useState(false);
 
   const safeBgColor = useMemo(() => normalizeHex(bgColor), [bgColor]);
+
+  const [hexDraft, setHexDraft] = useState(safeBgColor);
+
+  useEffect(() => {
+    setHexDraft(safeBgColor);
+  }, [safeBgColor]);
 
   const handleComplete = () => {
     setShowPicker(false);
@@ -114,12 +120,15 @@ export default function ProfileCustomSheet({
               <HexColorPicker color={safeBgColor} onChange={onChangeBgColor} />
               <div className="mt-2 flex items-center justify-between gap-2">
                 <input
-                  value={safeBgColor}
-                  onChange={(e) => onChangeBgColor(normalizeHex(e.target.value))}
+                  value={hexDraft}
+                  onChange={(e) => setHexDraft(e.target.value)}
                   className="w-28 rounded border px-2 py-1 text-sm"
                 />
                 <button
-                  onClick={handleClosePicker}
+                  onClick={() => {
+                    onChangeBgColor(normalizeHex(hexDraft));
+                    handleClosePicker();
+                  }}
                   className="rounded bg-gray-100 px-3 py-1 text-sm"
                   type="button"
                 >

--- a/src/components/home/ProfileCustomSheet.tsx
+++ b/src/components/home/ProfileCustomSheet.tsx
@@ -53,7 +53,6 @@ export default function ProfileCustomSheet({
     setShowPicker(next);
     onPickerStateChange?.(next);
 
-    // 배경색 피커를 열 때 스티커 선택 해제
     if (next) {
       onDeselectSticker?.();
     }
@@ -68,64 +67,68 @@ export default function ProfileCustomSheet({
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center pointer-events-none">
-      <div className="relative w-[393px] min-h-screen bg-black/40 overflow-hidden pointer-events-none">
+      <div className="relative w-full max-w-[440px] min-h-screen bg-black/40 overflow-hidden pointer-events-none">
         <button
           type="button"
           onClick={handleComplete}
-          className="absolute top-[79px] left-[309px] flex items-center justify-center w-[57px] h-[29px] bg-[#FF5F2F] rounded-[18px] px-[16px] py-[6px] gap-[10px] cursor-pointer pointer-events-auto"
+          className="absolute right-[16px] top-[41px] flex h-[29px] w-[57px] items-center justify-center rounded-[18px] bg-[#FF5F2F] px-[16px] py-[6px] cursor-pointer pointer-events-auto"
         >
-          <p className="absolute w-[25px] h-[17px] text-white font-semibold text-[14px]">완료</p>
+          <p className="text-white font-semibold text-[14px] leading-none">완료</p>
         </button>
 
-        <div className="pointer-events-auto fixed bottom-0 left-1/2 h-[225px] w-[393px] -translate-x-1/2 rounded-t-[17px] bg-white">
-          <div className="flex h-full flex-col">
-            <div className="flex items-center justify-center mt-[54px] gap-[54px]">
-              <button
-                type="button"
-                onClick={handleClickSticker}
-                className="flex h-[56px] w-[56px] items-center justify-center rounded-[6px] border border-[#E6E7E9] bg-[#F4F5F6] cursor-pointer"
-              >
-                <img src={stickerIcon} alt="sticker-icon" />
-              </button>
-              <p className="absolute top-[126px] left-[122px] text-[#555557] font-medium text-[14px] leading-[100%] w-[37px] h-[17px] text-center">
-                스티커
-              </p>
-
-              <button
-                type="button"
-                onClick={handleToggleBgPicker}
-                className="flex h-[56px] w-[56px] items-center justify-center rounded-[6px] border border-[#E6E7E9] bg-[#F4F5F6] cursor-pointer"
-              >
-                <img src={bgIcon} alt="bg-icon" />
-              </button>
-              <p className="absolute top-[126px] left-[233px] text-[#555557] font-medium text-[14px] leading-[100%] w-[37px] h-[17px] text-center">
-                배경색
-              </p>
-            </div>
-
-            {showPicker && (
-              <div className="absolute left-1/2 -translate-x-1/2 bottom-[235px] z-[60]">
-                <div className="bg-white rounded-lg p-3 shadow-lg">
-                  <HexColorPicker color={safeBgColor} onChange={onChangeBgColor} />
-                  <div className="mt-2 flex items-center gap-2 justify-between">
-                    <input
-                      value={safeBgColor}
-                      onChange={(e) => onChangeBgColor(normalizeHex(e.target.value))}
-                      className="w-28 rounded border px-2 py-1 text-sm"
-                    />
-                    <button
-                      onClick={handleClosePicker}
-                      className="px-3 py-1 rounded bg-gray-100 text-sm"
-                      type="button"
-                    >
-                      선택
-                    </button>
-                  </div>
-                </div>
+        <div className="pointer-events-auto fixed bottom-0 left-1/2 h-[225px] w-full max-w-[440px] -translate-x-1/2 rounded-t-[17px] bg-white">
+          <div className="flex h-full flex-col items-center">
+            <div className="mt-[54px] flex items-start justify-center gap-[54px]">
+              <div className="flex flex-col items-center gap-[14px]">
+                <button
+                  type="button"
+                  onClick={handleClickSticker}
+                  className="flex h-[56px] w-[56px] items-center justify-center rounded-[6px] border border-[#E6E7E9] bg-[#F4F5F6] cursor-pointer"
+                >
+                  <img src={stickerIcon} alt="sticker-icon" />
+                </button>
+                <p className="w-[37px] text-center text-[14px] font-medium leading-[100%] text-[#555557]">
+                  스티커
+                </p>
               </div>
-            )}
+
+              <div className="flex flex-col items-center gap-[14px]">
+                <button
+                  type="button"
+                  onClick={handleToggleBgPicker}
+                  className="flex h-[56px] w-[56px] items-center justify-center rounded-[6px] border border-[#E6E7E9] bg-[#F4F5F6] cursor-pointer"
+                >
+                  <img src={bgIcon} alt="bg-icon" />
+                </button>
+                <p className="w-[48px] text-center text-[14px] font-medium leading-[100%] text-[#555557]">
+                  배경색
+                </p>
+              </div>
+            </div>
           </div>
         </div>
+
+        {showPicker && (
+          <div className="absolute left-1/2 bottom-[235px] z-[60] -translate-x-1/2 pointer-events-auto">
+            <div className="rounded-lg bg-white p-3 shadow-lg">
+              <HexColorPicker color={safeBgColor} onChange={onChangeBgColor} />
+              <div className="mt-2 flex items-center justify-between gap-2">
+                <input
+                  value={safeBgColor}
+                  onChange={(e) => onChangeBgColor(normalizeHex(e.target.value))}
+                  className="w-28 rounded border px-2 py-1 text-sm"
+                />
+                <button
+                  onClick={handleClosePicker}
+                  className="rounded bg-gray-100 px-3 py-1 text-sm"
+                  type="button"
+                >
+                  선택
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
 
         <input
           ref={fileInputRef}

--- a/src/components/letterBox/FromBottomSheet.tsx
+++ b/src/components/letterBox/FromBottomSheet.tsx
@@ -21,9 +21,9 @@ export default function FromBottomSheet({
 }: FromBottomSheetProps) {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
-      <div className="relative w-[393px] min-h-screen overflow-hidden">
+      <div className="relative w-full max-w-[440px] min-h-screen overflow-hidden">
         <button type="button" onClick={onClose} className="absolute inset-0 bg-black/40" />
-        <div className="fixed bottom-0 left-1/2 w-[393px] h-[260px] -translate-x-1/2 rounded-t-[17px] bg-white">
+        <div className="fixed bottom-0 left-1/2 w-full max-w-[440px] h-[260px] -translate-x-1/2 rounded-t-[17px] bg-white">
           <div className="flex h-full flex-col">
             <p className="mt-[21px] text-center text-[18px] font-semibold text-[#141517]">
               From 선택

--- a/src/components/letterBox/SearchBar.tsx
+++ b/src/components/letterBox/SearchBar.tsx
@@ -1,7 +1,5 @@
 // 검색창
 
-import type { ChangeEvent } from 'react';
-
 export default function SearchBar({
   value,
   onChange,
@@ -12,7 +10,7 @@ export default function SearchBar({
   onClose: () => void;
 }) {
   return (
-    <div className="relative flex h-[50px] w-[361px] bg-white items-center rounded-xl border-[1.2px] border-[#C2C4C7] shadow-[0px_0px_12px_0px_#0000001A] focus-within:border-black">
+    <div className="relative h-[50px] w-full max-w-[440px] rounded-xl border-[1.2px] border-[#C2C4C7] bg-white shadow-[0px_0px_12px_0px_#0000001A] focus-within:border-black">
       <p
         className={`pointer-events-none absolute left-[22px] top-1/2 -translate-y-1/2 text-[16px] font-medium text-[#C2C4C7] transition-opacity ${
           value ? 'opacity-0' : 'opacity-100'
@@ -23,7 +21,7 @@ export default function SearchBar({
 
       <input
         value={value}
-        onChange={(e: ChangeEvent<HTMLInputElement>) => onChange(e.target.value)}
+        onChange={(e) => onChange(e.target.value)}
         spellCheck={false}
         autoCorrect="off"
         autoCapitalize="off"
@@ -36,7 +34,7 @@ export default function SearchBar({
           onChange('');
           onClose();
         }}
-        className="absolute right-3 top-1/2 -translate-y-1/2 text-[14px] font-medium text-[#BEBEBE] cursor-pointer"
+        className="absolute right-3 top-1/2 -translate-y-1/2 -translate-y-1/2 cursor-pointer text-[14px] font-medium text-[#BEBEBE]"
       >
         취소
       </button>

--- a/src/components/letterBox/SearchBar.tsx
+++ b/src/components/letterBox/SearchBar.tsx
@@ -34,7 +34,7 @@ export default function SearchBar({
           onChange('');
           onClose();
         }}
-        className="absolute right-3 top-1/2 -translate-y-1/2 -translate-y-1/2 cursor-pointer text-[14px] font-medium text-[#BEBEBE]"
+        className="absolute right-3 top-1/2 -translate-y-1/2 cursor-pointer text-[14px] font-medium text-[#BEBEBE]"
       >
         취소
       </button>

--- a/src/components/letterBox/ToolBar.tsx
+++ b/src/components/letterBox/ToolBar.tsx
@@ -49,7 +49,7 @@ export default function ToolBar({
 
   return (
     <>
-      <div className="relative flex w-[361px] h-[25px] mt-5 items-center justify-between">
+      <div className="relative flex max-w-[440px] h-[25px] mt-5 items-center justify-between">
         <div className="text-[14px] font-semibold text-[#141517]">총 {folderTotalCount}통</div>
 
         <div className="relative flex items-center">

--- a/src/components/letterBox/letterFolder/FolderList.tsx
+++ b/src/components/letterBox/letterFolder/FolderList.tsx
@@ -60,7 +60,7 @@ export default function FolderList({
   };
 
   return (
-    <div className="flex gap-[10px] p-[28px] overflow-x-auto no-scrollbar">
+    <div className="flex gap-[10px] p-[28px] pt-0 overflow-x-auto no-scrollbar">
       <div className="flex flex-col items-center gap-2 shrink-0" onClick={() => onSelect('all')}>
         <button
           type="button"

--- a/src/components/letterBox/letterFolder/FolderList.tsx
+++ b/src/components/letterBox/letterFolder/FolderList.tsx
@@ -60,7 +60,7 @@ export default function FolderList({
   };
 
   return (
-    <div className="flex gap-[10px] px-4 py-3 overflow-x-auto no-scrollbar -mt-[10px]">
+    <div className="flex gap-[10px] p-[28px] overflow-x-auto no-scrollbar">
       <div className="flex flex-col items-center gap-2 shrink-0" onClick={() => onSelect('all')}>
         <button
           type="button"

--- a/src/components/skeleton/LetterCardSkeleton.tsx
+++ b/src/components/skeleton/LetterCardSkeleton.tsx
@@ -6,7 +6,7 @@ type Props = {
 
 function DefaultSkeleton() {
   return (
-    <div className="w-full shadow-[0_0_4px_0_rgba(217,217,217,0.5)] rounded-lg animate-pulse">
+    <div className="w-full max-w-[440px] shadow-[0_0_4px_0_rgba(217,217,217,0.5)] rounded-lg animate-pulse">
       <div className="rounded-lg bg-white px-3 py-3 h-[121px] flex flex-col">
         <div className="flex justify-between">
           <div className="h-[12px] w-[60px] rounded bg-gray-200" />
@@ -30,7 +30,7 @@ function DefaultSkeleton() {
 
 function LetterCardCompactSkeleton() {
   return (
-    <div className="w-full h-[46px] rounded-lg bg-white px-3 py-2 flex items-center justify-between animate-pulse">
+    <div className="w-full max-w-[440px] h-[46px] rounded-lg bg-white px-3 py-2 flex items-center justify-between animate-pulse">
       <div className="flex items-center gap-[12px] flex-1 min-w-0">
         <div className="relative h-6 w-6 flex items-center justify-center">
           <div className="absolute inset-0 m-auto w-[14px] h-[14px] rounded-full bg-gray-200" />

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -57,7 +57,7 @@ export function AppLayout() {
     NO_MAIN_PADDING_PATHS.includes(pathname) ||
     (pathname.startsWith('/letter/') && pathname.endsWith('/edit'));
 
-  const HEADER_HEIGHT = 105;
+  const HEADER_HEIGHT = 78;
   const BOTTOM_NAV_HEIGHT = 95;
   const FIXED_ACTION_HEIGHT = 52 + 20 + 16;
   const bottomInset = fixedAction ? FIXED_ACTION_HEIGHT : hideBottomNav ? 0 : BOTTOM_NAV_HEIGHT;

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -86,7 +86,7 @@ export function AppLayout() {
           paddingTop: shouldShowHeader ? `calc(${HEADER_HEIGHT}px + 20px)` : noMainPadding ? 0 : 20,
         }}
       >
-        <div  className={`${noMainPadding ? '' : 'px-4'} w-full min-w-0 flex-1 flex flex-col`}>
+        <div className={`${noMainPadding ? '' : 'px-4'} w-full min-w-0 flex-1 flex flex-col`}>
           <Outlet context={{ homeBgColor, setHomeBgColor, setFixedAction }} />
         </div>
       </main>

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -52,7 +52,7 @@ export function AppLayout() {
 
   const bgClass = matched?.bg === 'white' ? 'bg-white' : 'bg-[#F8F8F8]';
 
-  const NO_MAIN_PADDING_PATHS = ['/my', '/my/account', 'letterbox', '/create/detail'];
+  const NO_MAIN_PADDING_PATHS = ['/my', '/my/account', '/letterbox', '/create/detail'];
   const noMainPadding =
     NO_MAIN_PADDING_PATHS.includes(pathname) ||
     (pathname.startsWith('/letter/') && pathname.endsWith('/edit'));

--- a/src/pages/letter/LetterBoxPage.tsx
+++ b/src/pages/letter/LetterBoxPage.tsx
@@ -278,9 +278,9 @@ export default function LetterBoxPage() {
           />
         </div>
       </div>
-
+      {/* top값 나중에 다시 수정 */}
       {isSearchOpen && (
-        <div className="fixed left-0 right-0 top-[60px] z-50 flex justify-center">
+        <div className="fixed left-0 right-0 top-[34px] z-50 flex justify-center">
           <div className="w-full max-w-[440px] px-4">
             <SearchBar
               value={query}

--- a/src/pages/letter/LetterBoxPage.tsx
+++ b/src/pages/letter/LetterBoxPage.tsx
@@ -280,15 +280,17 @@ export default function LetterBoxPage() {
       </div>
 
       {isSearchOpen && (
-        <div className="fixed top-[60px] left-1/2 z-50 -translate-x-1/2">
-          <SearchBar
-            value={query}
-            onChange={setQuery}
-            onClose={() => {
-              setQuery('');
-              setIsSearchOpen(false);
-            }}
-          />
+        <div className="fixed left-0 right-0 top-[60px] z-50 flex justify-center">
+          <div className="w-full max-w-[440px] px-4">
+            <SearchBar
+              value={query}
+              onChange={setQuery}
+              onClose={() => {
+                setQuery('');
+                setIsSearchOpen(false);
+              }}
+            />
+          </div>
         </div>
       )}
 

--- a/src/pages/letter/LetterBoxPage.tsx
+++ b/src/pages/letter/LetterBoxPage.tsx
@@ -258,13 +258,13 @@ export default function LetterBoxPage() {
   const emptyMessage = useMemo(() => {
     if (query.trim()) return '검색 결과가 없어요.';
     if (selectedFromId !== 'all') return '필터링 결과가 없어요.';
-    return '추가된 편지가 없어요.';
+    return '추가된 편지가 없어요';
   }, [query, selectedFromId]);
 
   return (
     <>
       <div className="fixed top-0 left-0 right-0 z-50 flex justify-center">
-        <div className="w-full max-w-[393px]">
+        <div className="w-full max-w-[440px]">
           <LetterBoxHeader
             title="편지함"
             left={
@@ -337,7 +337,15 @@ export default function LetterBoxPage() {
               ))}
             </div>
           ) : filteredLetters.length === 0 ? (
-            <div className="py-12 text-center text-[#9D9D9F] text-[15px]">{emptyMessage}</div>
+            <div className="flex flex-col py-[147px] text-center text-[#A1A4AA] text-[15px] justify-center items-center gap-4">
+              {emptyMessage}
+              <button
+                onClick={() => navigate('/create')}
+                className="w-[125px] h-[38px] bg-white rounded-[8px] border-[#E7E8EB] border-[1.2px] text-[#585A5F] cursor-pointer"
+              >
+                편지 추가
+              </button>
+            </div>
           ) : (
             filteredLetters.map((letter) => (
               <div

--- a/src/pages/report/ReportPage.tsx
+++ b/src/pages/report/ReportPage.tsx
@@ -83,8 +83,8 @@ export default function ReportPage() {
   return (
     <div className="flex flex-col">
       <div className="flex-1 pb-1 space-y-7">
-        <button className="cursor-pointer">
-          <img src={report} alt="report-recap" className="w-full h-32" />
+        <button className="cursor-pointer w-full max-w-[440px]">
+          <img src={report} alt="report-recap" className="w-full max-w-[440px]" />
         </button>
 
         {/* TOP3 영역 */}


### PR DESCRIPTION
## #️⃣ 관련 이슈
- close #138

---

## 📝 작업 요약
이번 PR에서 수행한 작업을 간단히 설명해주세요.
- 편지함 반응형 구현

---

## 🔧 변경 사항
- 편지함 전체 반응형 적용
- 폴더 리스트 패딩값 수정
- 편지 없음 -> 버튼 추가

---

## 💬 리뷰어 참고 사항
리뷰 시 참고하면 좋을 점이나 고민했던 부분이 있다면 작성해주세요.

---

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [x] 로컬에서 정상 동작을 확인했습니다.
- [x] UI 변경 사항을 직접 확인했습니다.
- [x] 불필요한 console.log를 제거했습니다.
- [x] 관련 이슈를 연결했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리즈 노트

* **스타일**
  * 여러 컴포넌트의 그림자 및 버튼 시각효과를 일관되게 조정했습니다.
  * 여러 패널·시트·모달의 너비를 고정에서 반응형(max-width)으로 변경했습니다.

* **레이아웃**
  * 검색창, 툴바, 폴더 리스트 등 패딩·정렬·정렬 제약을 정리해 배치가 개선되었습니다.
  * 헤더 높이 및 내부 정렬을 조정해 상단 여백이 변경되었습니다.

* **새로운 기능**
  * 편지함 빈 상태에 편지 추가 버튼을 함께 표시합니다.

* **Chores**
  * 일부 문장부호 및 텍스트 마감 문구를 정리했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->