### PR TITLE
[FEAT][sami] 편지 추가, 편지 상세, 프롬 관리 페이지 반응형 적용

### DIFF
--- a/src/components/common/BottomButton.tsx
+++ b/src/components/common/BottomButton.tsx
@@ -17,7 +17,7 @@ export function BottomButton({
       disabled={disabled}
       onClick={onClick}
       className={`
-        w-full max-w-[361px] h-[50px] rounded-xl font-bold text-base text-white
+        w-full max-w-[440px] h-[50px] rounded-xl font-bold text-base text-white
         transition-all
         ${
           disabled

--- a/src/components/common/ImageViewer.tsx
+++ b/src/components/common/ImageViewer.tsx
@@ -114,7 +114,7 @@ const getDistance = (t1: TouchPoint, t2: TouchPoint) => {
   return createPortal(
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       <div
-        className="relative w-[393px] h-full bg-black flex items-center justify-center"
+        className="relative w-full max-w-[440px] h-full bg-black flex items-center justify-center"
         onClick={onClose}
       >
         <div

--- a/src/components/letter/FolderSelect.tsx
+++ b/src/components/letter/FolderSelect.tsx
@@ -19,7 +19,7 @@ export default function FolderSelect({
 
   return (
     <div className="fixed inset-0 z-50 flex justify-center">
-      <div className="relative w-[393px] min-h-screen flex items-center justify-center">
+      <div className="relative w-full max-w-[440px] min-h-screen flex items-center justify-center">
         <button
           type="button"
           onClick={onClose}

--- a/src/components/letter/LetterDetailBottomSheet.tsx
+++ b/src/components/letter/LetterDetailBottomSheet.tsx
@@ -30,7 +30,7 @@ export default function LetterDetailBottomSheet({
 
   return (
     <div className="fixed inset-0 z-50 flex justify-center">
-      <div className="relative w-[393px] min-h-screen">
+      <div className="relative w-full max-w-[440px] min-h-screen">
         <button
           onClick={onClose}
           className="absolute inset-0 bg-black/40"

--- a/src/components/skeleton/EditLetterSkeleton.tsx
+++ b/src/components/skeleton/EditLetterSkeleton.tsx
@@ -1,7 +1,6 @@
 export default function EditLetterSkeleton() {
   return (
     <>
-      {/* 헤더 스켈레톤 */}
       <div className="px-4 pt-15 pb-2 animate-pulse">
         <div className="h-[56px] flex items-center justify-between">
           <div className="h-4 w-8 rounded bg-[#E0E0E0]" />

--- a/src/pages/create/CreateDetailPage.tsx
+++ b/src/pages/create/CreateDetailPage.tsx
@@ -53,12 +53,12 @@ export default function CreateDetailPage() {
   return (
     <>
     <div className="fixed top-0 left-0 right-0 z-50 flex justify-center">
-        <div className="w-full max-w-[393px]">
+        <div className="w-full max-w-[440px]">
       <CreateDetailHeader images={headerImages} />
       </div>
       </div>
 
-      <div className="mt-[129px] flex-1 px-4">
+      <div className="mt-[98px] flex-1 px-4">
         <LetterForm
       mode="create"
       content={content}

--- a/src/pages/letter/EditLetterPage.tsx
+++ b/src/pages/letter/EditLetterPage.tsx
@@ -148,7 +148,7 @@ export default function EditLetterPage() {
         </div>
       </div>
 
-      <div className="mt-[125px] flex-1 px-4">
+      <div className="mt-[98px] flex-1 px-4">
         {showSubmittingLoading ? (
           <LoadingSection
             className="pt-25"

--- a/src/pages/letter/EditLetterPage.tsx
+++ b/src/pages/letter/EditLetterPage.tsx
@@ -143,7 +143,7 @@ export default function EditLetterPage() {
   return (
     <>
       <div className="fixed top-0 left-0 right-0 z-50 flex justify-center">
-        <div className="w-full max-w-[393px]">
+        <div className="w-full max-w-[440px]">
           <EditLetterHeader images={headerImages} />
         </div>
       </div>

--- a/src/pages/my/ProfilePage.tsx
+++ b/src/pages/my/ProfilePage.tsx
@@ -233,7 +233,7 @@ export default function ProfilePage() {
     <div className="min-h-screen bg-white">
       {isCropping && cropImageUrl && (
         <div className="fixed inset-0 z-50 flex items-center justify-center">
-          <div className="relative w-[393px] max-w-full h-full bg-black flex flex-col">
+          <div className="relative w-full max-w-[440px] h-full bg-black flex flex-col">
             <div
               className="flex items-center justify-between px-4 mb-2 text-white text-base font-normal"
               style={{ paddingTop: 'max(env(safe-area-inset-top, 0px), 16px)' }}


### PR DESCRIPTION
## #️⃣ 관련 이슈
- close #140 

---

## 📝 작업 요약
편지 추가, 편지 상세, 프롬 관리 페이지 반응형 적용

---

## 🔧 변경 사항
반응형 적용
- 편지 추가
- 편지 수정
- 프롬 선택
- 프롬 관리

---

## 💬 리뷰어 참고 사항
리뷰 시 참고하면 좋을 점이나 고민했던 부분이 있다면 작성해주세요.

---

## ✅ 체크리스트
- [X] 커밋 메시지 컨벤션을 준수했습니다.
- [X] 로컬에서 정상 동작을 확인했습니다.
- [X] UI 변경 사항을 직접 확인했습니다.
- [X] 불필요한 console.log를 제거했습니다.
- [X] 관련 이슈를 연결했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 버튼, 바텀 시트, 폴더 선택 UI 등 핵심 컴포넌트의 최대 너비를 확대하여 더 넓은 화면에서 레이아웃 여유와 가독성 향상
  * 작성·편집·프로필 페이지의 헤더와 본문 간 세로 여백을 조정해 시각적 균형 및 정렬 개선
  * 여러 컴포넌트에서 반응형 동작을 강화해 다양한 화면 크기에서 일관된 UI 경험 제공
<!-- end of auto-generated comment: release notes by coderabbit.ai -->