### PR TITLE
[FIX] 데스크톱 달력 영역 수정 및 프롬 중복 토스트 띄워주기

### DIFF
--- a/src/components/common/LetterForm.tsx
+++ b/src/components/common/LetterForm.tsx
@@ -39,6 +39,27 @@ export default function LetterForm({
 
   const MAX_HEIGHT = LINE_HEIGHT * MAX_LINES + PADDING_Y;
 
+
+  const dateInputRef = useRef<HTMLInputElement>(null);
+
+  const openDatePicker = () => {
+    const input = dateInputRef.current;
+
+    if (!input || unknownDate) return;
+
+    try {
+      if (typeof input.showPicker === "function") {
+        input.showPicker();
+      } else {
+        input.focus();
+        input.click();
+      }
+    } catch {
+      input.focus();
+      input.click();
+    }
+  };
+
   useLayoutEffect(() => {
     const el = textareaRef.current;
     if (!el) return;
@@ -163,44 +184,68 @@ const formatDatePreview = (value: string) => {
         </p>
 
         <div className="flex items-center gap-4">
-          <div className="relative flex-1 h-[45px]">
+          <div
+            role="button"
+            tabIndex={unknownDate ? -1 : 0}
+            onClick={openDatePicker}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                openDatePicker();
+              }
+            }}
+            className={`
+              relative flex-1 h-[45px]
+              ${unknownDate ? "cursor-default" : "cursor-pointer"}
+            `}
+          >
             <input
+              ref={dateInputRef}
               type="date"
               value={date}
               onChange={(e) => {
-                const next = e.target.value; // 서버로 넘길 값: YYYY-MM-DD
+                const next = e.target.value;
+
                 setDate(next);
                 onDateChange?.(next);
               }}
               disabled={unknownDate}
               className="
-                absolute inset-0 w-full h-full
-                opacity-0 cursor-pointer
+                absolute inset-0
+                z-10
+                w-full h-full
+                opacity-0
+                cursor-pointer
               "
             />
 
             <div
               className={`
+                pointer-events-none
                 w-full h-[45px]
                 border border-[#E7E8EB]
-                rounded-xl px-4 text-sm font-medium
+                rounded-xl
+                px-4
+                text-sm font-medium
                 flex items-center
                 ${date ? "text-[#585A5F]" : "text-[#C7C7CC]"}
-                ${unknownDate ? "bg-[#F7F8F9]" : "bg-[#FFFFFF]"}
+                ${unknownDate ? "bg-[#F7F8F9]" : "bg-white"}
               `}
             >
               {date ? formatDatePreview(date) : "YY-MM-DD"}
             </div>
           </div>
 
-          <label className="flex items-center gap-2 text-sm font-medium text-[#585A5F]">
+          <label className="flex items-center gap-2 text-sm font-medium text-[#585A5F] cursor-pointer">
             <input
               type="checkbox"
               checked={unknownDate}
               onChange={(e) => {
                 const checked = e.target.checked;
+
                 setUnknownDate(checked);
                 onUnknownDateChange?.(checked);
+
                 if (checked) {
                   setDate("");
                   onDateChange?.("");
@@ -208,6 +253,7 @@ const formatDatePreview = (value: string) => {
               }}
               className="checkbox-accent checkbox-custom"
             />
+
             날짜 모름
           </label>
         </div>

--- a/src/components/header/EditLetterHeader.tsx
+++ b/src/components/header/EditLetterHeader.tsx
@@ -15,7 +15,7 @@ export default function EditLetterHeader({ images }: Props) {
     <ThumbnailHeader
       title="편지 수정"
       confirmTitle="편지 수정 취소"
-      confirmDescription="편지 수정을 취소할까요? 내용은 저장되지 않아요"
+      confirmDescription={"편지 수정을 취소할까요?\n내용은 저장되지 않아요"}
       images={images}
       onConfirmExit={() => {
         if (id) {

--- a/src/pages/create/SetFromPage.tsx
+++ b/src/pages/create/SetFromPage.tsx
@@ -11,6 +11,7 @@ import erasebtn from '@/assets/create/erasebtn.svg';
 import type { From } from '@/types/from';
 import { useFromList } from '@/hooks/queries/useFromList';
 import { hangulIncludes } from '@/utils/hangulSearch';
+import useToast from '@/hooks/useToast';
 
 type FromItem = From;
 
@@ -36,6 +37,7 @@ export default function SetFromPage() {
   const navigate = useNavigate();
   const location = useLocation();
   const state = location.state as SetFromPageState;
+  const toast = useToast();
 
   const { data: fromList = [] } = useFromList();
 
@@ -59,6 +61,27 @@ export default function SetFromPage() {
       },
     });
   };
+
+  const normalizeFromName = (name: string) =>
+  name.trim().replace(/\s+/g, ' ').toLowerCase();
+
+const handleDraftCreate = (draft: CreateFrom) => {
+  const normalizedDraftName = normalizeFromName(draft.name);
+
+  const isDuplicate = fromList.some(
+    (from) => normalizeFromName(from.name) === normalizedDraftName,
+  );
+
+  if (isDuplicate) {
+  toast.show('같은 이름의 프롬이 이미 있어요');
+  return;
+}
+
+  goBackWithDraft({
+    ...draft,
+    name: draft.name.trim(),
+  });
+};
 
   const handleSelect = (from: FromItem) => {
     goBackWithDraft({
@@ -181,11 +204,11 @@ export default function SetFromPage() {
             }
           />
           <FromCreator
-            onDraftCreate={goBackWithDraft}
-            name={addInput}
-            onNameChange={setAddInput}
-            fromCount={fromList.length}
-          />
+  onDraftCreate={handleDraftCreate}
+  name={addInput}
+  onNameChange={setAddInput}
+  fromCount={fromList.length}
+/>
         </div>
       )}
     </div>

--- a/src/pages/my/FromCreatePage.tsx
+++ b/src/pages/my/FromCreatePage.tsx
@@ -6,6 +6,7 @@ import type { CreateFrom } from '@/types/from';
 import erasebtn from '@/assets/create/erasebtn.svg';
 import useToast from '@/hooks/useToast';
 import { useCreateFrom } from '@/hooks/mutations/useCreateFrom';
+import { useFromList } from '@/hooks/queries/useFromList';
 
 export default function FromCreatePage() {
   const navigate = useNavigate();
@@ -13,18 +14,45 @@ export default function FromCreatePage() {
   const [input, setInput] = useState('');
   const createFromMutation = useCreateFrom();
 
+  const { data: fromList = [] } = useFromList();
+
+  const normalizeFromName = (name: string) =>
+    name.trim().replace(/\s+/g, ' ').toLocaleLowerCase();
+
   const handleCreateImmediate = async (draft: CreateFrom) => {
     if (createFromMutation.isPending) return;
+
+    const trimmedName = draft.name.trim();
+    const normalizedName = normalizeFromName(trimmedName);
+
+    const isDuplicate = fromList.some(
+      (from) => normalizeFromName(from.name) === normalizedName,
+    );
+
+    if (isDuplicate) {
+      toast.show('같은 이름의 프롬이 이미 있어요');
+      return;
+    }
+
     try {
-      const res = await createFromMutation.mutateAsync(draft);
+      const res = await createFromMutation.mutateAsync({
+        ...draft,
+        name: trimmedName,
+      });
+
       if (!res.success) {
         toast.show(res.message || '프롬 생성에 실패했어요.');
         return;
       }
+
       navigate('/my/from', {
         replace: true,
         state: {
-          createdFrom: { ...draft, fromId: res.data.fromId },
+          createdFrom: {
+            ...draft,
+            name: trimmedName,
+            fromId: res.data.fromId,
+          },
         },
       });
     } catch {
@@ -45,6 +73,7 @@ export default function FromCreatePage() {
           rightElement={
             input ? (
               <button
+                type="button"
                 onClick={() => setInput('')}
                 className="flex items-center justify-center w-6 h-6"
               >
@@ -66,4 +95,3 @@ export default function FromCreatePage() {
     </div>
   );
 }
-

--- a/src/pages/my/FromPage.tsx
+++ b/src/pages/my/FromPage.tsx
@@ -56,20 +56,37 @@ export default function FromPage() {
                 fromIndex={index}
                 onCancel={() => setEditingFromId(null)}
                 onSave={async (updated) => {
-                  try {
-                    await updateFromMutation.mutateAsync({
-                      fromId: updated.fromId,
-                      payload: {
-                        name: updated.name,
-                        bgColor: updated.bgColor,
-                        fontColor: updated.fontColor,
-                      },
-                    });
-                    setEditingFromId(null);
-                  } catch {
-                    toast.show('프롬 수정 중 오류가 발생했어요.');
-                  }
-                }}
+                const normalizeFromName = (name: string) =>
+                  name.trim().replace(/\s+/g, ' ').toLocaleLowerCase();
+
+                const trimmedName = updated.name.trim();
+
+                const isDuplicate = fromList.some(
+                  (item) =>
+                    item.fromId !== updated.fromId &&
+                    normalizeFromName(item.name) === normalizeFromName(trimmedName),
+                );
+
+                if (isDuplicate) {
+                  toast.show('같은 이름의 프롬이 이미 있어요');
+                  return;
+                }
+
+                try {
+                  await updateFromMutation.mutateAsync({
+                    fromId: updated.fromId,
+                    payload: {
+                      name: trimmedName,
+                      bgColor: updated.bgColor,
+                      fontColor: updated.fontColor,
+                    },
+                  });
+
+                  setEditingFromId(null);
+                } catch {
+                  toast.show('프롬 수정 중 오류가 발생했어요.');
+                }
+              }}
                 onDelete={async (id) => {
                   try {
                     await deleteFromMutation.mutateAsync(id);


### PR DESCRIPTION
## #️⃣ 관련 이슈
- close #217 

---

## 📝 작업 요약
데스크톱 달력 영역 수정 및 프롬 중복 시 토스트 띄워주기

---

## 🔧 변경 사항
- 마이페이지 UI 구현
- 사용자 정보 표시 로직 추가
- 버튼 및 인터랙션 처리

---

## 💬 리뷰어 참고 사항
리뷰 시 참고하면 좋을 점이나 고민했던 부분이 있다면 작성해주세요.

---

## ✅ 체크리스트
- [X] 커밋 메시지 컨벤션을 준수했습니다.
- [X] 로컬에서 정상 동작을 확인했습니다.
- [X] UI 변경 사항을 직접 확인했습니다.
- [X] 불필요한 console.log를 제거했습니다.
- [X] 관련 이슈를 연결했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 날짜 입력 영역을 클릭하거나 키보드로 선택해 날짜 선택기를 열 수 있습니다.
  * 날짜를 모르는 경우에도 기존 비활성화 및 초기화 동작이 유지됩니다.

* **버그 수정**
  * 프롬 생성 및 수정 시 앞뒤 공백과 중복 공백, 대소문자를 정리해 이름 중복을 정확히 확인합니다.
  * 중복된 이름은 저장되지 않으며 안내 토스트가 표시됩니다.
  * 저장되는 프롬 이름에서 불필요한 앞뒤 공백이 제거됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->