### PR TITLE
[FEAT] 프롬 선택 UI 수정사항 반영

### DIFF
--- a/src/components/common/FromBadge.tsx
+++ b/src/components/common/FromBadge.tsx
@@ -16,15 +16,15 @@ export function FromBadge({
   const sizeClass = {
     md: {
       outer: 'inline-flex px-[12px] py-[5px] rounded-[6px]',
-      text: 'flex items-center text-[13px] font-semibold',
+      text: 'flex items-center text-[13px] font-semibold whitespace-nowrap',
     },
     lg: {
       outer: 'inline-flex px-[14px] py-[6px] rounded-[6px]',
-      text: 'flex items-center text-[14px] font-semibold',
+      text: 'flex items-center text-[14px] font-semibold whitespace-nowrap',
     },
     xl: {
       outer: 'inline-flex items-center px-[14px] py-[6px] rounded-[6px]',
-      text: 'text-[16px] leading-[19px] font-semibold',
+      text: 'text-[15px] leading-[19px] font-semibold whitespace-nowrap',
     },
   };
 

--- a/src/components/common/FromCreator.tsx
+++ b/src/components/common/FromCreator.tsx
@@ -1,66 +1,31 @@
-// 프롬 생성하기 공용 UI - 검색창은 각각 컴포넌트에서 따로
+// 프롬 생성하기 공용 UI - 색상 선택 + 미리보기 (제출 로직/버튼은 각 페이지에서 처리)
 
 import { useState } from 'react';
 import { getHarmoniousTextColor } from '@/utils/color';
-import type { CreateFrom } from '@/types/from';
 import ColorPicker from '@/assets/create/color-picker.svg';
 import { HexColorPicker } from 'react-colorful';
-import Plusbtn from '@/assets/create/plusbtn.svg';
 import { FromBadge } from '@/components/common/FromBadge';
 
 type Props = {
-  onDraftCreate?: (draft: CreateFrom) => void; // 생성된 draft를 부모 컴포넌트로 전달(setFromPage)
-  onCreateImmediate?: (draft: CreateFrom) => Promise<any>; // 생성된 draft로 바로 프롬 생성 api 호출(fromCreatePage)
   name: string;
-  onNameChange: (v: string) => void;
-  disabled?: boolean;
-  fromCount?: number; // 현재 From 개수 (개수에 따라 컬러피커 위치 조정용)
+  selectedColor: string;
+  onColorChange: (c: string) => void;
 };
 
-export default function CreateFrom({
-  onDraftCreate,
-  onCreateImmediate,
-  name,
-  onNameChange,
-  disabled,
-}: Props) {
-  const [selectedColor, setSelectedColor] = useState('#FEEFEF');
+export default function CreateFrom({ name, selectedColor, onColorChange }: Props) {
   const [showPicker, setShowPicker] = useState(false);
 
-  const handleCreate = async () => {
-    const trimmed = name.trim();
-    if (!trimmed) return;
-
-    const shortName = trimmed.slice(0, 7); // 최대 7자 제한
-
-    const draft: CreateFrom = {
-      name: shortName,
-      bgColor: selectedColor,
-      fontColor: getHarmoniousTextColor(selectedColor),
-    };
-
-    if (onDraftCreate) {
-      onDraftCreate(draft);
-      return;
-    }
-
-    if (onCreateImmediate) {
-      await onCreateImmediate(draft);
-      onNameChange('');
-    }
-  };
-
   return (
-    <div className="mt-4">
-      <div className="flex mb-4 gap-2">
+    <div className="mt-7">
+      <div className="flex mb-3 gap-2">
         <div className="text-sm font-medium text-[#A1A4AA]">색상 선택</div>
       </div>
 
-      <div className="relative flex gap-3 mb-6 mt-4">
+      <div className="relative flex gap-3 mb-7">
         {['#FFE2DD', '#FFF3C4', '#EAF5FF', '#E4F7EB'].map((c) => (
           <button
             key={c}
-            onClick={() => setSelectedColor(c)}
+            onClick={() => onColorChange(c)}
             className={`w-[36px] h-[36px] rounded-full transition-all border-[1.2px] ${
               selectedColor === c ? 'border-primary' : 'border-transparent'
             }`}
@@ -76,15 +41,13 @@ export default function CreateFrom({
         </button>
 
         {showPicker && (
-        <div
-          className="absolute left-6/8 -translate-x-1/2 z-40 top-full mt-3"
-        >
-          <div className="bg-white rounded-lg p-3 shadow-lg">
-              <HexColorPicker color={selectedColor} onChange={(c) => setSelectedColor(c)} />
+          <div className="absolute left-6/8 -translate-x-1/2 z-40 top-full mt-3">
+            <div className="bg-white rounded-lg p-3 shadow-lg">
+              <HexColorPicker color={selectedColor} onChange={onColorChange} />
               <div className="mt-2 flex items-center gap-2 justify-between">
                 <input
                   value={selectedColor}
-                  onChange={(e) => setSelectedColor(e.target.value)}
+                  onChange={(e) => onColorChange(e.target.value)}
                   className="w-28 rounded border px-2 py-1 text-sm"
                 />
                 <button
@@ -99,11 +62,15 @@ export default function CreateFrom({
         )}
       </div>
 
-      <button onClick={handleCreate} className="flex items-center gap-2 font-normal text-lg text-primary" disabled={disabled}>
-        <img src={Plusbtn} alt="upload" />
-        <FromBadge size="xl" name={name || '이름'} bgColor={selectedColor} fontColor={getHarmoniousTextColor(selectedColor)} />
-        추가하기
-      </button>
+      <div className="w-full rounded-2xl bg-[#F7F8F9] border border-dashed border-[#CACBD1] px-[125px] py-[24px] flex flex-col items-center justify-center gap-3">
+        <p className="text-[13px] font-normal text-[#A1A4AA]">이렇게 만들어져요 👀</p>
+        <FromBadge
+          size="xl"
+          name={name || '이름'}
+          bgColor={selectedColor}
+          fontColor={getHarmoniousTextColor(selectedColor)}
+        />
+      </div>
     </div>
   );
 }

--- a/src/components/common/FromCreator.tsx
+++ b/src/components/common/FromCreator.tsx
@@ -64,12 +64,14 @@ export default function CreateFrom({ name, selectedColor, onColorChange }: Props
 
       <div className="w-full rounded-2xl bg-[#F7F8F9] border border-dashed border-[#CACBD1] px-[125px] py-[24px] flex flex-col items-center justify-center gap-3">
         <p className="text-[13px] font-normal text-[#A1A4AA]">이렇게 만들어져요 👀</p>
-        <FromBadge
-          size="xl"
-          name={name || '이름'}
-          bgColor={selectedColor}
-          fontColor={getHarmoniousTextColor(selectedColor)}
-        />
+        <div className="shadow-[0px_0px_4px_0px_rgba(0,0,0,0.12)] rounded-[6px]">
+          <FromBadge
+            size="xl"
+            name={name || '이름'}
+            bgColor={selectedColor}
+            fontColor={getHarmoniousTextColor(selectedColor)}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/components/letter/LetterDetailSection.tsx
+++ b/src/components/letter/LetterDetailSection.tsx
@@ -225,7 +225,7 @@ export default function LetterDetailSection({
           편지 카드 저장
         </BottomButton>
       ),
-      bgColor: "#F8F8F8",
+      bgColor: "#F7F8F9",
     });
 
     return () => {

--- a/src/components/my/FontRow.tsx
+++ b/src/components/my/FontRow.tsx
@@ -24,7 +24,7 @@ export function FontRow({
       type="button"
       onClick={onClick}
       className={clsx(
-        "w-[361px] h-[80px] text-left rounded-[12px] border-[1.2px] px-[20px] py-[21px] flex items-center justify-between",
+        "w-full h-[80px] text-left rounded-[12px] border-[1.2px] px-[20px] py-[21px] flex items-center justify-between",
         selected ? "border-[#141517]" : "border-[#E6E7E9]"
       )}
     >

--- a/src/components/my/from/FromEditPanel.tsx
+++ b/src/components/my/from/FromEditPanel.tsx
@@ -68,10 +68,8 @@ export default function FromEditPanel({ from, onCancel, onSave, onDelete, fromIn
           <button
             key={c}
             onClick={() => setSelectedColor(c)}
-            className={`w-[32px] h-[32px] rounded-full transition-all ${
-              selectedColor === c
-                ? 'scale-100 shadow-[0_0_8px_rgba(0,0,0,0.2)]'
-                : 'shadow-none'
+            className={`w-[32px] h-[32px] rounded-full transition-all border-[1.2px] ${
+              selectedColor === c ? 'border-primary' : 'border-transparent'
             }`}
             style={{ background: c }}
           />

--- a/src/constants/from.ts
+++ b/src/constants/from.ts
@@ -1,0 +1,1 @@
+export const FROM_NAME_MAX_LENGTH = 10;

--- a/src/hooks/useFromDraftForm.ts
+++ b/src/hooks/useFromDraftForm.ts
@@ -1,0 +1,56 @@
+import { useState } from 'react';
+import { useFromList } from '@/hooks/queries/useFromList';
+import { getHarmoniousTextColor } from '@/utils/color';
+import useToast from '@/hooks/useToast';
+import { FROM_NAME_MAX_LENGTH } from '@/constants/from';
+import type { CreateFrom } from '@/types/from';
+
+const normalizeFromName = (name: string) =>
+  name.trim().replace(/\s+/g, ' ').toLowerCase();
+
+export function useFromDraftForm(initialColor = '#FFA2A2') {
+  const [name, setNameRaw] = useState('');
+  const [selectedColor, setSelectedColor] = useState(initialColor);
+  const { data: fromList = [] } = useFromList();
+  const toast = useToast();
+
+  const setName = (v: string) => setNameRaw(v.slice(0, FROM_NAME_MAX_LENGTH));
+
+  const isDuplicateName = (candidate: string) => {
+    const normalized = normalizeFromName(candidate);
+    return fromList.some((from) => normalizeFromName(from.name) === normalized);
+  };
+
+  // 중복이면 토스트 띄우고 null 반환, 아니면 draft 객체 반환
+  const buildDraftOrWarn = (): CreateFrom | null => {
+    const trimmed = name.trim();
+    if (!trimmed) return null;
+
+    if (isDuplicateName(trimmed)) {
+      toast.show('같은 이름의 프롬이 이미 있어요');
+      return null;
+    }
+
+    return {
+      name: trimmed.slice(0, FROM_NAME_MAX_LENGTH),
+      bgColor: selectedColor,
+      fontColor: getHarmoniousTextColor(selectedColor),
+    };
+  };
+
+  const reset = () => {
+    setNameRaw('');
+    setSelectedColor(initialColor);
+  };
+
+  return {
+    name,
+    setName,
+    selectedColor,
+    setSelectedColor,
+    buildDraftOrWarn,
+    isDuplicateName,
+    fromList,
+    reset,
+  };
+}

--- a/src/hooks/useFromDraftForm.ts
+++ b/src/hooks/useFromDraftForm.ts
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useFromList } from '@/hooks/queries/useFromList';
+import { useCreateFrom } from '@/hooks/mutations/useCreateFrom';
 import { getHarmoniousTextColor } from '@/utils/color';
 import useToast from '@/hooks/useToast';
 import { FROM_NAME_MAX_LENGTH } from '@/constants/from';
@@ -12,6 +13,7 @@ export function useFromDraftForm(initialColor = '#FFA2A2') {
   const [name, setNameRaw] = useState('');
   const [selectedColor, setSelectedColor] = useState(initialColor);
   const { data: fromList = [] } = useFromList();
+  const createFromMutation = useCreateFrom();
   const toast = useToast();
 
   const setName = (v: string) => setNameRaw(v.slice(0, FROM_NAME_MAX_LENGTH));
@@ -21,8 +23,10 @@ export function useFromDraftForm(initialColor = '#FFA2A2') {
     return fromList.some((from) => normalizeFromName(from.name) === normalized);
   };
 
-  // 중복이면 토스트 띄우고 null 반환, 아니면 draft 객체 반환
-  const buildDraftOrWarn = (): CreateFrom | null => {
+  // 서버에 실제로 생성까지 완료 - 성공 시 fromId 포함된 draft 반환 / 실패, 중복, 빈값이면 null
+  const createFromAndGetDraft = async (): Promise<CreateFrom | null> => {
+    if (createFromMutation.isPending) return null;
+
     const trimmed = name.trim();
     if (!trimmed) return null;
 
@@ -31,11 +35,25 @@ export function useFromDraftForm(initialColor = '#FFA2A2') {
       return null;
     }
 
-    return {
+    const payload = {
       name: trimmed.slice(0, FROM_NAME_MAX_LENGTH),
       bgColor: selectedColor,
       fontColor: getHarmoniousTextColor(selectedColor),
     };
+
+    try {
+      const res = await createFromMutation.mutateAsync(payload);
+
+      if (!res.success) {
+        toast.show(res.message || '프롬 생성에 실패했어요');
+        return null;
+      }
+
+      return { ...payload, fromId: res.data.fromId };
+    } catch {
+      toast.show('프롬 생성 중 오류가 발생했어요');
+      return null;
+    }
   };
 
   const reset = () => {
@@ -48,7 +66,8 @@ export function useFromDraftForm(initialColor = '#FFA2A2') {
     setName,
     selectedColor,
     setSelectedColor,
-    buildDraftOrWarn,
+    createFromAndGetDraft,
+    isCreating: createFromMutation.isPending,
     isDuplicateName,
     fromList,
     reset,

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -9,6 +9,9 @@ import { FONT_FAMILY } from '@/utils/fontMap';
 export type AppLayoutContext = {
   homeBgColor: string;
   setHomeBgColor: (color: string) => void;
+  setFixedAction: (
+    action: { node: React.ReactNode; bgColor?: string } | null,
+  ) => void;
 };
 
 export function AppLayout() {

--- a/src/pages/create/SetFromPage.tsx
+++ b/src/pages/create/SetFromPage.tsx
@@ -1,5 +1,3 @@
-// 서버 응답 X - goBackWithDraft로 상태 전달하여 이전 페이지에서 처리
-
 import { useEffect, useState } from 'react';
 import { useLocation, useNavigate, useOutletContext } from 'react-router-dom';
 import type { CreateResultPayload } from '@/types/create';
@@ -44,8 +42,9 @@ export default function SetFromPage() {
     setName: setAddInput,
     selectedColor,
     setSelectedColor,
-    buildDraftOrWarn,
+    createFromAndGetDraft,
     fromList,
+    isCreating,
   } = useFromDraftForm();
 
   const goBackWithDraft = (draft: CreateFrom) => {
@@ -69,8 +68,8 @@ export default function SetFromPage() {
     });
   };
 
-  const handleDraftCreate = () => {
-    const draft = buildDraftOrWarn();
+  const handleDraftCreate = async () => {
+    const draft = await createFromAndGetDraft();
     if (!draft) return;
     goBackWithDraft(draft);
   };
@@ -93,14 +92,14 @@ export default function SetFromPage() {
 
     setFixedAction({
       node: (
-        <BottomButton disabled={!addInput.trim()} onClick={handleDraftCreate}>
+        <BottomButton disabled={!addInput.trim() || isCreating} onClick={handleDraftCreate}>
           추가하기
         </BottomButton>
       ),
     });
 
     return () => setFixedAction(null);
-  }, [tab, addInput, selectedColor, fromList]);
+  }, [tab, addInput, selectedColor, fromList, isCreating]);
 
   return (
     <div className="flex flex-col h-full">

--- a/src/pages/create/SetFromPage.tsx
+++ b/src/pages/create/SetFromPage.tsx
@@ -3,18 +3,16 @@
 import { useEffect, useState } from 'react';
 import { useLocation, useNavigate, useOutletContext } from 'react-router-dom';
 import type { CreateResultPayload } from '@/types/create';
-import type { CreateFrom } from '@/types/from';
+import type { CreateFrom, From } from '@/types/from';
 import { FromBadge } from '@/components/common/FromBadge';
 import { InputField } from '@/components/common/InputField';
 import FromCreator from '@/components/common/FromCreator';
 import { BottomButton } from '@/components/common/BottomButton';
 import erasebtn from '@/assets/create/erasebtn.svg';
-import type { From } from '@/types/from';
-import { useFromList } from '@/hooks/queries/useFromList';
 import { hangulIncludes } from '@/utils/hangulSearch';
-import { getHarmoniousTextColor } from '@/utils/color';
-import useToast from '@/hooks/useToast';
+import { useFromDraftForm } from '@/hooks/useFromDraftForm';
 import type { AppLayoutContext } from '@/layouts/AppLayout';
+import { FROM_NAME_MAX_LENGTH } from '@/constants/from';
 
 type FromItem = From;
 
@@ -36,15 +34,19 @@ type SetFromPageState =
 export default function SetFromPage() {
   const [tab, setTab] = useState<'select' | 'add'>('select');
   const [searchInput, setSearchInput] = useState('');
-  const [addInput, setAddInput] = useState('');
-  const [selectedColor, setSelectedColor] = useState('#FFA2A2');
   const navigate = useNavigate();
   const location = useLocation();
   const state = location.state as SetFromPageState;
-  const toast = useToast();
   const { setFixedAction } = useOutletContext<AppLayoutContext>();
 
-  const { data: fromList = [] } = useFromList();
+  const {
+    name: addInput,
+    setName: setAddInput,
+    selectedColor,
+    setSelectedColor,
+    buildDraftOrWarn,
+    fromList,
+  } = useFromDraftForm();
 
   const goBackWithDraft = (draft: CreateFrom) => {
     if (state && 'mode' in state && state.mode === 'edit') {
@@ -67,28 +69,10 @@ export default function SetFromPage() {
     });
   };
 
-  const normalizeFromName = (name: string) =>
-    name.trim().replace(/\s+/g, ' ').toLowerCase();
-
   const handleDraftCreate = () => {
-    const trimmed = addInput.trim();
-    if (!trimmed) return;
-
-    const normalizedDraftName = normalizeFromName(trimmed);
-    const isDuplicate = fromList.some(
-      (from) => normalizeFromName(from.name) === normalizedDraftName,
-    );
-
-    if (isDuplicate) {
-      toast.show('같은 이름의 프롬이 이미 있어요');
-      return;
-    }
-
-    goBackWithDraft({
-      name: trimmed.slice(0, 7),
-      bgColor: selectedColor,
-      fontColor: getHarmoniousTextColor(selectedColor),
-    });
+    const draft = buildDraftOrWarn();
+    if (!draft) return;
+    goBackWithDraft(draft);
   };
 
   const handleSelect = (from: FromItem) => {
@@ -148,7 +132,7 @@ export default function SetFromPage() {
               onChange={setSearchInput}
               placeholder="이름 검색"
               useGrayWhenBlurred
-              maxLength={9}
+              maxLength={FROM_NAME_MAX_LENGTH}
               inputClassName="h-[50px] rounded-xl px-4 text-base font-medium outline-none cursor-text focus:bg-white focus:ring-1 focus:ring-primary mb-4"
               rightElement={
                 searchInput ? (
@@ -161,7 +145,7 @@ export default function SetFromPage() {
                 ) : undefined
               }
             />
-            <div className="flex flex-col gap-[24px] mt-2 justify-center">
+            <div className="flex flex-col gap-[24px] mt-2 justify-center mb-5">
               {fromList.length === 0 ? (
                 <div className="w-full flex flex-col items-center justify-center gap-[16px] min-h-[320px]">
                   <p className="font-normal text-[15px] text-[#A1A4AA]">
@@ -209,14 +193,16 @@ export default function SetFromPage() {
         <div className="flex flex-col h-full mt-5">
           <div className="flex mb-3 justify-between">
             <div className="text-sm font-medium text-[#A1A4AA]">이름 입력</div>
-            <div className="text-sm font-medium text-[#A1A4AA]">{addInput.length}/10</div>
+            <div className="text-sm font-medium text-[#A1A4AA]">
+              {addInput.length}/{FROM_NAME_MAX_LENGTH}
+            </div>
           </div>
           <InputField
             value={addInput}
-            onChange={(v) => setAddInput(v.slice(0, 10))}
+            onChange={setAddInput}
             placeholder="편지를 준 사람의 이름"
             useGrayWhenBlurred
-            maxLength={10}
+            maxLength={FROM_NAME_MAX_LENGTH}
             inputClassName="h-[50px] rounded-xl px-4 text-base font-medium outline-none cursor-text focus:bg-white focus:ring-1 focus:ring-primary"
             rightElement={
               addInput ? (

--- a/src/pages/create/SetFromPage.tsx
+++ b/src/pages/create/SetFromPage.tsx
@@ -1,17 +1,20 @@
 // 서버 응답 X - goBackWithDraft로 상태 전달하여 이전 페이지에서 처리
 
-import { useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { useLocation, useNavigate, useOutletContext } from 'react-router-dom';
 import type { CreateResultPayload } from '@/types/create';
 import type { CreateFrom } from '@/types/from';
 import { FromBadge } from '@/components/common/FromBadge';
 import { InputField } from '@/components/common/InputField';
 import FromCreator from '@/components/common/FromCreator';
+import { BottomButton } from '@/components/common/BottomButton';
 import erasebtn from '@/assets/create/erasebtn.svg';
 import type { From } from '@/types/from';
 import { useFromList } from '@/hooks/queries/useFromList';
 import { hangulIncludes } from '@/utils/hangulSearch';
+import { getHarmoniousTextColor } from '@/utils/color';
 import useToast from '@/hooks/useToast';
+import type { AppLayoutContext } from '@/layouts/AppLayout';
 
 type FromItem = From;
 
@@ -34,10 +37,12 @@ export default function SetFromPage() {
   const [tab, setTab] = useState<'select' | 'add'>('select');
   const [searchInput, setSearchInput] = useState('');
   const [addInput, setAddInput] = useState('');
+  const [selectedColor, setSelectedColor] = useState('#FFA2A2');
   const navigate = useNavigate();
   const location = useLocation();
   const state = location.state as SetFromPageState;
   const toast = useToast();
+  const { setFixedAction } = useOutletContext<AppLayoutContext>();
 
   const { data: fromList = [] } = useFromList();
 
@@ -63,25 +68,28 @@ export default function SetFromPage() {
   };
 
   const normalizeFromName = (name: string) =>
-  name.trim().replace(/\s+/g, ' ').toLowerCase();
+    name.trim().replace(/\s+/g, ' ').toLowerCase();
 
-const handleDraftCreate = (draft: CreateFrom) => {
-  const normalizedDraftName = normalizeFromName(draft.name);
+  const handleDraftCreate = () => {
+    const trimmed = addInput.trim();
+    if (!trimmed) return;
 
-  const isDuplicate = fromList.some(
-    (from) => normalizeFromName(from.name) === normalizedDraftName,
-  );
+    const normalizedDraftName = normalizeFromName(trimmed);
+    const isDuplicate = fromList.some(
+      (from) => normalizeFromName(from.name) === normalizedDraftName,
+    );
 
-  if (isDuplicate) {
-  toast.show('같은 이름의 프롬이 이미 있어요');
-  return;
-}
+    if (isDuplicate) {
+      toast.show('같은 이름의 프롬이 이미 있어요');
+      return;
+    }
 
-  goBackWithDraft({
-    ...draft,
-    name: draft.name.trim(),
-  });
-};
+    goBackWithDraft({
+      name: trimmed.slice(0, 7),
+      bgColor: selectedColor,
+      fontColor: getHarmoniousTextColor(selectedColor),
+    });
+  };
 
   const handleSelect = (from: FromItem) => {
     goBackWithDraft({
@@ -91,6 +99,24 @@ const handleDraftCreate = (draft: CreateFrom) => {
       fontColor: from.fontColor,
     });
   };
+
+  // 새로 추가 탭일 때만 하단 버튼
+  useEffect(() => {
+    if (tab !== 'add') {
+      setFixedAction(null);
+      return;
+    }
+
+    setFixedAction({
+      node: (
+        <BottomButton disabled={!addInput.trim()} onClick={handleDraftCreate}>
+          추가하기
+        </BottomButton>
+      ),
+    });
+
+    return () => setFixedAction(null);
+  }, [tab, addInput, selectedColor, fromList]);
 
   return (
     <div className="flex flex-col h-full">
@@ -138,17 +164,17 @@ const handleDraftCreate = (draft: CreateFrom) => {
             <div className="flex flex-col gap-[24px] mt-2 justify-center">
               {fromList.length === 0 ? (
                 <div className="w-full flex flex-col items-center justify-center gap-[16px] min-h-[320px]">
-                <p className="font-normal text-[15px] text-[#A1A4AA]">
-                  추가된 From이 없어요
-                </p>
+                  <p className="font-normal text-[15px] text-[#A1A4AA]">
+                    추가된 From이 없어요
+                  </p>
 
-                <button
-                  className="w-[125px] h-[38px] bg-[#ffffff] text-[#585A5F] border-[1.2px] border-[#E7E8EB] rounded-lg text-sm font-medium"
-                  onClick={() => setTab('add')}
-                >
-                  새로 추가
-                </button>
-              </div>
+                  <button
+                    className="w-[125px] h-[38px] bg-[#ffffff] text-[#585A5F] border-[1.2px] border-[#E7E8EB] rounded-lg text-sm font-medium"
+                    onClick={() => setTab('add')}
+                  >
+                    새로 추가
+                  </button>
+                </div>
               ) : (
                 fromList
                   .filter((from) => hangulIncludes(from.name, searchInput))
@@ -167,7 +193,7 @@ const handleDraftCreate = (draft: CreateFrom) => {
                       </div>
                       <button
                         onClick={() => handleSelect(from)}
-                        className="text-[13px] font-normal text-[#A1A4AA] border border-[#CACBD1] rounded-lg px-[12px] py-[5px]"
+                        className="text-[13px] font-normal text-[#A1A4AA] bg-[#F7F8F9] border border-[#CACBD1] rounded-lg px-[12px] py-[5px]"
                       >
                         선택
                       </button>
@@ -181,17 +207,17 @@ const handleDraftCreate = (draft: CreateFrom) => {
 
       {tab === 'add' && (
         <div className="flex flex-col h-full mt-5">
-          <div className="flex mb-4 justify-between">
+          <div className="flex mb-3 justify-between">
             <div className="text-sm font-medium text-[#A1A4AA]">이름 입력</div>
-            <div className="text-sm font-medium text-[#CACBD1]">{addInput.length}/10</div>
+            <div className="text-sm font-medium text-[#A1A4AA]">{addInput.length}/10</div>
           </div>
           <InputField
             value={addInput}
-            onChange={setAddInput}
+            onChange={(v) => setAddInput(v.slice(0, 10))}
             placeholder="편지를 준 사람의 이름"
             useGrayWhenBlurred
-            maxLength={9}
-            inputClassName="h-[50px] rounded-xl px-4 text-base font-medium outline-none cursor-text focus:bg-white focus:ring-1 focus:ring-primary mb-4"
+            maxLength={10}
+            inputClassName="h-[50px] rounded-xl px-4 text-base font-medium outline-none cursor-text focus:bg-white focus:ring-1 focus:ring-primary"
             rightElement={
               addInput ? (
                 <button
@@ -204,11 +230,10 @@ const handleDraftCreate = (draft: CreateFrom) => {
             }
           />
           <FromCreator
-  onDraftCreate={handleDraftCreate}
-  name={addInput}
-  onNameChange={setAddInput}
-  fromCount={fromList.length}
-/>
+            name={addInput}
+            selectedColor={selectedColor}
+            onColorChange={setSelectedColor}
+          />
         </div>
       )}
     </div>

--- a/src/pages/my/FromCreatePage.tsx
+++ b/src/pages/my/FromCreatePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useNavigate, useOutletContext } from 'react-router-dom';
 import { InputField } from '@/components/common/InputField';
 import FromCreator from '@/components/common/FromCreator';
@@ -6,44 +6,30 @@ import { BottomButton } from '@/components/common/BottomButton';
 import erasebtn from '@/assets/create/erasebtn.svg';
 import useToast from '@/hooks/useToast';
 import { useCreateFrom } from '@/hooks/mutations/useCreateFrom';
-import { useFromList } from '@/hooks/queries/useFromList';
-import { getHarmoniousTextColor } from '@/utils/color';
+import { useFromDraftForm } from '@/hooks/useFromDraftForm';
 import type { AppLayoutContext } from '@/layouts/AppLayout';
+import { FROM_NAME_MAX_LENGTH } from '@/constants/from';
 
 export default function FromCreatePage() {
   const navigate = useNavigate();
   const toast = useToast();
-  const [input, setInput] = useState('');
-  const [selectedColor, setSelectedColor] = useState('#FFA2A2');
   const createFromMutation = useCreateFrom();
   const { setFixedAction } = useOutletContext<AppLayoutContext>();
 
-  const { data: fromList = [] } = useFromList();
-
-  const normalizeFromName = (name: string) =>
-    name.trim().replace(/\s+/g, ' ').toLocaleLowerCase();
+  const {
+    name: input,
+    setName: setInput,
+    selectedColor,
+    setSelectedColor,
+    buildDraftOrWarn,
+    fromList,
+  } = useFromDraftForm();
 
   const handleCreateImmediate = async () => {
     if (createFromMutation.isPending) return;
 
-    const trimmedName = input.trim();
-    if (!trimmedName) return;
-
-    const normalizedName = normalizeFromName(trimmedName);
-    const isDuplicate = fromList.some(
-      (from) => normalizeFromName(from.name) === normalizedName,
-    );
-
-    if (isDuplicate) {
-      toast.show('같은 이름의 프롬이 이미 있어요');
-      return;
-    }
-
-    const draft = {
-      name: trimmedName.slice(0, 7),
-      bgColor: selectedColor,
-      fontColor: getHarmoniousTextColor(selectedColor),
-    };
+    const draft = buildDraftOrWarn();
+    if (!draft) return;
 
     try {
       const res = await createFromMutation.mutateAsync(draft);
@@ -82,36 +68,38 @@ export default function FromCreatePage() {
     return () => setFixedAction(null);
   }, [input, selectedColor, createFromMutation.isPending, fromList]);
 
-return (
-  <div className="flex flex-col h-full">
-    <div className="flex mb-3 justify-between mt-1">
-      <div className="text-sm font-medium text-[#A1A4AA]">이름 입력</div>
-      <div className="text-sm font-medium text-[#A1A4AA]">{input.length}/10</div>
-    </div>
-    <InputField
-      value={input}
-      onChange={(v) => setInput(v.slice(0, 10))}
-      placeholder="편지를 준 사람의 이름"
-      useGrayWhenBlurred
-      maxLength={10}
-      inputClassName="h-[50px] rounded-xl px-4 text-base font-medium outline-none cursor-text focus:bg-white focus:ring-1 focus:ring-primary"
-      rightElement={
-        input ? (
-          <button
-            onClick={() => setInput('')}
-            className="flex items-center justify-center w-6 h-6"
-          >
-            <img src={erasebtn} alt="clear" className="w-5 h-5 block" />
-          </button>
-        ) : undefined
-      }
-    />
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex mb-3 justify-between mt-1">
+        <div className="text-sm font-medium text-[#A1A4AA]">이름 입력</div>
+        <div className="text-sm font-medium text-[#A1A4AA]">
+          {input.length}/{FROM_NAME_MAX_LENGTH}
+        </div>
+      </div>
+      <InputField
+        value={input}
+        onChange={setInput}
+        placeholder="편지를 준 사람의 이름"
+        useGrayWhenBlurred
+        maxLength={FROM_NAME_MAX_LENGTH}
+        inputClassName="h-[50px] rounded-xl px-4 text-base font-medium outline-none cursor-text focus:bg-white focus:ring-1 focus:ring-primary"
+        rightElement={
+          input ? (
+            <button
+              onClick={() => setInput('')}
+              className="flex items-center justify-center w-6 h-6"
+            >
+              <img src={erasebtn} alt="clear" className="w-5 h-5 block" />
+            </button>
+          ) : undefined
+        }
+      />
 
-    <FromCreator
-      name={input}
-      selectedColor={selectedColor}
-      onColorChange={setSelectedColor}
-    />
-  </div>
-);
+      <FromCreator
+        name={input}
+        selectedColor={selectedColor}
+        onColorChange={setSelectedColor}
+      />
+    </div>
+  );
 }

--- a/src/pages/my/FromCreatePage.tsx
+++ b/src/pages/my/FromCreatePage.tsx
@@ -4,16 +4,12 @@ import { InputField } from '@/components/common/InputField';
 import FromCreator from '@/components/common/FromCreator';
 import { BottomButton } from '@/components/common/BottomButton';
 import erasebtn from '@/assets/create/erasebtn.svg';
-import useToast from '@/hooks/useToast';
-import { useCreateFrom } from '@/hooks/mutations/useCreateFrom';
 import { useFromDraftForm } from '@/hooks/useFromDraftForm';
 import type { AppLayoutContext } from '@/layouts/AppLayout';
 import { FROM_NAME_MAX_LENGTH } from '@/constants/from';
 
 export default function FromCreatePage() {
   const navigate = useNavigate();
-  const toast = useToast();
-  const createFromMutation = useCreateFrom();
   const { setFixedAction } = useOutletContext<AppLayoutContext>();
 
   const {
@@ -21,43 +17,26 @@ export default function FromCreatePage() {
     setName: setInput,
     selectedColor,
     setSelectedColor,
-    buildDraftOrWarn,
+    createFromAndGetDraft,
+    isCreating,
     fromList,
   } = useFromDraftForm();
 
   const handleCreateImmediate = async () => {
-    if (createFromMutation.isPending) return;
-
-    const draft = buildDraftOrWarn();
+    const draft = await createFromAndGetDraft();
     if (!draft) return;
 
-    try {
-      const res = await createFromMutation.mutateAsync(draft);
-
-      if (!res.success) {
-        toast.show(res.message || '프롬 생성에 실패했어요.');
-        return;
-      }
-
-      navigate('/my/from', {
-        replace: true,
-        state: {
-          createdFrom: {
-            ...draft,
-            fromId: res.data.fromId,
-          },
-        },
-      });
-    } catch {
-      toast.show('프롬 생성 중 오류가 발생했어요.');
-    }
+    navigate('/my/from', {
+      replace: true,
+      state: { createdFrom: draft },
+    });
   };
 
   useEffect(() => {
     setFixedAction({
       node: (
         <BottomButton
-          disabled={!input.trim() || createFromMutation.isPending}
+          disabled={!input.trim() || isCreating}
           onClick={handleCreateImmediate}
         >
           추가하기
@@ -66,7 +45,7 @@ export default function FromCreatePage() {
     });
 
     return () => setFixedAction(null);
-  }, [input, selectedColor, createFromMutation.isPending, fromList]);
+  }, [input, selectedColor, isCreating, fromList]);
 
   return (
     <div className="flex flex-col h-full">

--- a/src/pages/my/FromCreatePage.tsx
+++ b/src/pages/my/FromCreatePage.tsx
@@ -1,30 +1,35 @@
-import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { useNavigate, useOutletContext } from 'react-router-dom';
 import { InputField } from '@/components/common/InputField';
 import FromCreator from '@/components/common/FromCreator';
-import type { CreateFrom } from '@/types/from';
+import { BottomButton } from '@/components/common/BottomButton';
 import erasebtn from '@/assets/create/erasebtn.svg';
 import useToast from '@/hooks/useToast';
 import { useCreateFrom } from '@/hooks/mutations/useCreateFrom';
 import { useFromList } from '@/hooks/queries/useFromList';
+import { getHarmoniousTextColor } from '@/utils/color';
+import type { AppLayoutContext } from '@/layouts/AppLayout';
 
 export default function FromCreatePage() {
   const navigate = useNavigate();
   const toast = useToast();
   const [input, setInput] = useState('');
+  const [selectedColor, setSelectedColor] = useState('#FFA2A2');
   const createFromMutation = useCreateFrom();
+  const { setFixedAction } = useOutletContext<AppLayoutContext>();
 
   const { data: fromList = [] } = useFromList();
 
   const normalizeFromName = (name: string) =>
     name.trim().replace(/\s+/g, ' ').toLocaleLowerCase();
 
-  const handleCreateImmediate = async (draft: CreateFrom) => {
+  const handleCreateImmediate = async () => {
     if (createFromMutation.isPending) return;
 
-    const trimmedName = draft.name.trim();
-    const normalizedName = normalizeFromName(trimmedName);
+    const trimmedName = input.trim();
+    if (!trimmedName) return;
 
+    const normalizedName = normalizeFromName(trimmedName);
     const isDuplicate = fromList.some(
       (from) => normalizeFromName(from.name) === normalizedName,
     );
@@ -34,11 +39,14 @@ export default function FromCreatePage() {
       return;
     }
 
+    const draft = {
+      name: trimmedName.slice(0, 7),
+      bgColor: selectedColor,
+      fontColor: getHarmoniousTextColor(selectedColor),
+    };
+
     try {
-      const res = await createFromMutation.mutateAsync({
-        ...draft,
-        name: trimmedName,
-      });
+      const res = await createFromMutation.mutateAsync(draft);
 
       if (!res.success) {
         toast.show(res.message || '프롬 생성에 실패했어요.');
@@ -50,7 +58,6 @@ export default function FromCreatePage() {
         state: {
           createdFrom: {
             ...draft,
-            name: trimmedName,
             fromId: res.data.fromId,
           },
         },
@@ -60,38 +67,51 @@ export default function FromCreatePage() {
     }
   };
 
-  return (
-    <div>
-      <div className="p-0 mt-3 px-0">
-        <InputField
-          value={input}
-          onChange={setInput}
-          placeholder="이름을 입력하세요"
-          useGrayWhenBlurred
-          maxLength={7}
-          inputClassName="h-[50px] rounded-xl px-4 text-base font-medium outline-none cursor-text focus:bg-white focus:ring-1 focus:ring-primary"
-          rightElement={
-            input ? (
-              <button
-                type="button"
-                onClick={() => setInput('')}
-                className="flex items-center justify-center w-6 h-6"
-              >
-                <img src={erasebtn} alt="clear" />
-              </button>
-            ) : undefined
-          }
-        />
-      </div>
+  useEffect(() => {
+    setFixedAction({
+      node: (
+        <BottomButton
+          disabled={!input.trim() || createFromMutation.isPending}
+          onClick={handleCreateImmediate}
+        >
+          추가하기
+        </BottomButton>
+      ),
+    });
 
-      <div className="mt-[26px]">
-        <FromCreator
-          onCreateImmediate={handleCreateImmediate}
-          name={input}
-          onNameChange={setInput}
-          disabled={createFromMutation.isPending}
-        />
-      </div>
+    return () => setFixedAction(null);
+  }, [input, selectedColor, createFromMutation.isPending, fromList]);
+
+return (
+  <div className="flex flex-col h-full">
+    <div className="flex mb-3 justify-between mt-1">
+      <div className="text-sm font-medium text-[#A1A4AA]">이름 입력</div>
+      <div className="text-sm font-medium text-[#A1A4AA]">{input.length}/10</div>
     </div>
-  );
+    <InputField
+      value={input}
+      onChange={(v) => setInput(v.slice(0, 10))}
+      placeholder="편지를 준 사람의 이름"
+      useGrayWhenBlurred
+      maxLength={10}
+      inputClassName="h-[50px] rounded-xl px-4 text-base font-medium outline-none cursor-text focus:bg-white focus:ring-1 focus:ring-primary"
+      rightElement={
+        input ? (
+          <button
+            onClick={() => setInput('')}
+            className="flex items-center justify-center w-6 h-6"
+          >
+            <img src={erasebtn} alt="clear" className="w-5 h-5 block" />
+          </button>
+        ) : undefined
+      }
+    />
+
+    <FromCreator
+      name={input}
+      selectedColor={selectedColor}
+      onColorChange={setSelectedColor}
+    />
+  </div>
+);
 }

--- a/src/pages/my/StylePage.tsx
+++ b/src/pages/my/StylePage.tsx
@@ -50,6 +50,7 @@ export default function StylePage() {
           변경
         </BottomButton>
       ),
+      bgColor: '#F7F8F9',
     });
 
     return () => setFixedAction(null);
@@ -63,7 +64,7 @@ export default function StylePage() {
         </div>
 
         <div
-          className="rounded-[15px] w-[361px] h-[175px] shadow-[0_0_2px_rgba(0,0,0,0.08)] py-[40px] bg-white"
+          className="rounded-[15px] w-full h-[175px] shadow-[0_0_2px_rgba(0,0,0,0.08)] py-[40px] bg-white"
           style={{ fontFamily: current.fontFamily }}
           >
           <div className="text-center text-[18px] font-medium leading-[1.5] text-[#141517]">


### PR DESCRIPTION
## #️⃣ 관련 이슈
- close #219 

---

## 📝 작업 요약
프롬 선택 UI 수정 사항 반영

---

## 🔧 변경 사항
- 편지 추가 -> 프롬 선택 및 프롬 설정 - 생성 페이지 UI 수정사항 반영
- 프롬 생성하기 공용 컴포넌트로 분리 - 색상 선택 + 미리보기 (제출 로직/버튼은 각 페이지에서 처리)
- 프롬 생성하기 로직 훅으로 분리
- 프롬 글자 수 -> 프롬 뱃지 줄바꿈 문제 해결
- 편지 추가 -> 프롬 선택에서 추가하기 버튼 누르면 즉시 생성으로 수정
ㄴ 편지 상세, 수정의 if (!fromId) create 분기는 그대로 유지 (fallback 안전망)

---

## 💬 리뷰어 참고 사항
리뷰 시 참고하면 좋을 점이나 고민했던 부분이 있다면 작성해주세요.

---

## ✅ 체크리스트
- [X] 커밋 메시지 컨벤션을 준수했습니다.
- [X] 로컬에서 정상 동작을 확인했습니다.
- [X] UI 변경 사항을 직접 확인했습니다.
- [X] 불필요한 console.log를 제거했습니다.
- [X] 관련 이슈를 연결했습니다.
