### PR TITLE
[FIX][mumi] 스타일 페이지 레이아웃 불균형 수정

### DIFF
--- a/src/components/my/FontRow.tsx
+++ b/src/components/my/FontRow.tsx
@@ -24,7 +24,7 @@ export function FontRow({
       type="button"
       onClick={onClick}
       className={clsx(
-        "w-[361px] h-[80px] text-left rounded-[12px] border-[1.2px] px-[20px] py-[21px] flex items-center justify-between",
+        "w-full min-h-[80px] text-left rounded-[12px] border-[1.2px] px-[20px] py-[21px] flex items-center justify-between gap-[12px]",
         selected ? "border-[#141517]" : "border-[#E6E7E9]"
       )}
     >

--- a/src/pages/my/StylePage.tsx
+++ b/src/pages/my/StylePage.tsx
@@ -63,9 +63,9 @@ export default function StylePage() {
         </div>
 
         <div
-          className="rounded-[15px] w-[361px] h-[175px] shadow-[0_0_2px_rgba(0,0,0,0.08)] py-[40px] bg-white"
+          className="rounded-[15px] w-full h-auto min-h-[175px] shadow-[0_0_2px_rgba(0,0,0,0.08)] py-[40px] px-[16px] bg-white"
           style={{ fontFamily: current.fontFamily }}
-          >
+        >
           <div className="text-center text-[18px] font-medium leading-[1.5] text-[#141517]">
             “너는 충분히 잘하고 있어.
             <br />
@@ -96,8 +96,7 @@ export default function StylePage() {
                 preview={opt.preview}
                 fontFamily={opt.fontFamily}
                 onClick={() => {
-                  if (locked)
-                    return;
+                  if (locked) return;
                   setPendingFont(opt.key);
                 }}
               />


### PR DESCRIPTION
## #️⃣ 관련 이슈
- close #

---

## 📝 작업 요약
- 스타일 페이지 레이아웃 불균형 수정
- 반응형 적용

---

## 🔧 변경 사항
- 스타일 페이지 레이아웃 불균형 수정
- 반응형 적용

---

## 💬 리뷰어 참고 사항
리뷰 시 참고하면 좋을 점이나 고민했던 부분이 있다면 작성해주세요.

---

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [x] 로컬에서 정상 동작을 확인했습니다.
- [x] UI 변경 사항을 직접 확인했습니다.
- [x] 불필요한 console.log를 제거했습니다.
- [x] 관련 이슈를 연결했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일 개선**
  * 글꼴 행과 스타일 미리보기 카드가 화면 너비에 맞춰 유연하게 표시되도록 개선했습니다.
  * 콘텐츠 양에 따라 카드 높이가 자연스럽게 조정됩니다.

* **버그 수정**
  * 잠긴 글꼴 옵션이 클릭되지 않도록 기존 동작을 안정적으로 유지했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->