### PR TITLE
[FIX][mumi] 로그인 직후 폰트 미반영 문제 수정

### DIFF
--- a/src/pages/my/MyhomePage.tsx
+++ b/src/pages/my/MyhomePage.tsx
@@ -10,10 +10,8 @@ import ChevronRightIcon from '@/components/icons/ChevronRightIcon';
 import ProfilePlaceholderIcon from '@/components/icons/ProfilePlaceholderIcon';
 import type { MyProfileSectionProps } from '@/components/my/types';
 
-import { useStyleStore } from '@/stores/styleStores';
 import { useAuthStore } from '@/stores/authStore';
 
-import { getMyTheme, serverFontToClient } from '@/api/theme';
 import { useMeQuery } from '@/hooks/queries/useMeQuery';
 
 const KAKAO_CHANNEL_URL = 'https://pf.kakao.com/_DIxexnX';
@@ -64,30 +62,11 @@ export function MyProfileSection({ nickname, profileImageUrl }: MyProfileSection
 }
 
 export default function MyhomePage() {
-  const setFont = useStyleStore((s) => s.setFont);
   const setAuthStatus = useAuthStore((s) => s.setAuthStatus);
 
   const navigate = useNavigate();
 
   const { data: me, isError: isMeError } = useMeQuery();
-
-  useEffect(() => {
-    let mounted = true;
-
-    (async () => {
-      try {
-        const theme = await getMyTheme();
-        if (!mounted) return;
-        setFont(serverFontToClient(theme.font));
-      } catch {
-        setAuthStatus('unauthenticated');
-        navigate('/login', { replace: true });
-      }
-    })();
-    return () => {
-      mounted = false;
-    };
-  }, [navigate, setAuthStatus, setFont]);
 
   useEffect(() => {
     if (isMeError) {

--- a/src/routes/AuthGuard.tsx
+++ b/src/routes/AuthGuard.tsx
@@ -1,11 +1,37 @@
 // 인증 라우트 가드
 
+import { useEffect, useRef } from 'react';
 import { Navigate, Outlet, useLocation } from 'react-router-dom';
 import { useAuthStore } from '@/stores/authStore';
+import { useStyleStore } from '@/stores/styleStores';
+import { getMyTheme, serverFontToClient } from '@/api/theme';
 
 export default function RequireAuth() {
   const authStatus = useAuthStore((s) => s.authStatus);
   const location = useLocation();
+
+  const setFont = useStyleStore((s) => s.setFont);
+  const fontFetchedRef = useRef(false);
+
+  useEffect(() => {
+    if (authStatus === 'authenticated' && !fontFetchedRef.current) {
+      fontFetchedRef.current = true;
+
+      (async () => {
+        try {
+          const theme = await getMyTheme();
+          setFont(serverFontToClient(theme.font));
+        } catch (e) {
+          console.error(e);
+        }
+      })();
+    }
+
+    // 로그아웃되면 다음 로그인 때 다시 fetch 하도록 리셋
+    if (authStatus === 'unauthenticated') {
+      fontFetchedRef.current = false;
+    }
+  }, [authStatus, setFont]);
 
   if (authStatus === 'checking') {
     return <div>로딩 중...</div>;


### PR DESCRIPTION
## #️⃣ 관련 이슈

- close #234

---

## 📝 작업 요약

- 로그인 직후 폰트 미반영 문제 수정

---

## 🔧 변경 사항

- 로그인 직후 폰트 미반영 문제 수정

---

## 💬 리뷰어 참고 사항

리뷰 시 참고하면 좋을 점이나 고민했던 부분이 있다면 작성해주세요.

---

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [x] 로컬에서 정상 동작을 확인했습니다.
- [x] UI 변경 사항을 직접 확인했습니다.
- [x] 불필요한 console.log를 제거했습니다.
- [x] 관련 이슈를 연결했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 로그인 완료 후 사용자 테마의 글꼴 설정이 전역 스타일에 자동으로 적용됩니다.
  * 로그아웃 후 다시 로그인하면 테마 글꼴을 새로 불러옵니다.
  * 사용자 정보 조회 실패 시 로그인 화면으로 이동하는 기존 동작을 유지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->