### PR TITLE
[FEAT] 초대 시트 API 연동

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,9 +2,8 @@ import router from '@/routes/router';
 import { RouterProvider } from 'react-router-dom';
 import { ToastProvider } from '@/components/common/ToastProvider';
 import AuthProvider from './providers/AuthProvider';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-
-const queryClient = new QueryClient();
+import { QueryClientProvider } from '@tanstack/react-query';
+import { queryClient } from '@/api/queryClient';
 
 function App() {
   return (

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,6 +1,9 @@
 import { api } from '@/api/http';
 
-export async function getOAuthAuthorizeUrl(provider: 'kakao' | 'google') {
-  const res = await api.get(`/auth/oauth2/${provider}`);
+// 초대 링크로 진입한 경우 inviteCode를 함께 넘김
+export async function getOAuthAuthorizeUrl(provider: 'kakao' | 'google', inviteCode?: string) {
+  const res = await api.get(`/auth/oauth2/${provider}`, {
+    params: inviteCode ? { inviteCode } : undefined,
+  });
   return res.data.data.authorizeUrl as string;
 }

--- a/src/api/http.ts
+++ b/src/api/http.ts
@@ -3,6 +3,7 @@ import { useStyleStore } from '@/stores/styleStores';
 import axios, { AxiosError, type AxiosRequestConfig } from 'axios';
 import type { UserProfile, UpdateMeRequest, UpdateMeResponse } from '@/types/user';
 import { normalizeImageUrl } from './upload';
+import { clearQueryCacheOnAuthChange } from './queryClient';
 
 export const api = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL,
@@ -103,6 +104,7 @@ api.interceptors.response.use(
     } catch (refreshError) {
       delete api.defaults.headers.common.Authorization;
       useAuthStore.getState().setAuthStatus('unauthenticated');
+      clearQueryCacheOnAuthChange();
 
       return Promise.reject(refreshError);
     } finally {
@@ -122,6 +124,9 @@ export async function logout() {
 
     useStyleStore.getState().resetStyle();
     localStorage.removeItem('deare-style');
+
+    // 다음 계정이 이전 계정의 캐시(me, inviteLink 등)를 읽지 않도록 전부 폐기
+    clearQueryCacheOnAuthChange();
   }
 }
 

--- a/src/api/invite.ts
+++ b/src/api/invite.ts
@@ -1,0 +1,19 @@
+import { api, publicApi } from '@/api/http';
+import type { CommonResponse } from '@/types/common';
+import type { InviteLink, InviteVerify } from '@/types/invite';
+
+// 내 초대 코드 및 링크 발급
+// 서버에서 사용자당 하나의 코드를 재사용하므로 반복 호출해도 링크가 새로 생기지 않음
+export async function getInviteLink() {
+  const { data } = await api.get<CommonResponse<InviteLink>>('/invites/code');
+  return data.data;
+}
+
+// 초대 코드 유효성 검증
+// 비로그인 상태로 초대 링크를 타고 들어오는 경우이므로 인증 헤더가 붙지 않는 publicApi 사용
+export async function getInviteVerify(inviteCode: string) {
+  const { data } = await publicApi.get<CommonResponse<InviteVerify>>(
+    `/invites/${encodeURIComponent(inviteCode)}/validate`
+  );
+  return data.data;
+}

--- a/src/api/queryClient.ts
+++ b/src/api/queryClient.ts
@@ -1,0 +1,11 @@
+// React 외부에서도 캐시를 다뤄야 해서 싱글턴으로 분리
+
+import { QueryClient } from '@tanstack/react-query';
+
+export const queryClient = new QueryClient();
+
+// 계정이 바뀔 때(로그아웃 / 세션 만료) 이전 계정 데이터를 전부 폐기
+// 고정 키 + staleTime을 쓰는 쿼리가 다음 계정으로 새는 것을 방지
+export function clearQueryCacheOnAuthChange() {
+  queryClient.clear();
+}

--- a/src/components/common/FriendInviteSheet.tsx
+++ b/src/components/common/FriendInviteSheet.tsx
@@ -25,7 +25,7 @@ export default function FriendInviteSheet({ open, onClose, onInvite }: FriendInv
 
             <div className="flex flex-col gap-[8px] text-[14px] font-medium text-[#585A5F]">
               <p>초대 링크를 통해 1명만 가입해도</p>
-              <p>테마·스티커·폰트를 마음껏 이용할 수 있어요!</p>
+              <p>친구와, 나 둘 다 꾸미기 기능을 마음껏 이용할 수 있어요!</p>
             </div>
           </div>
         </div>

--- a/src/constants/invite.ts
+++ b/src/constants/invite.ts
@@ -1,0 +1,8 @@
+// 초대 링크 공유 문구
+
+const INVITE_SHARE_MESSAGE = `[dear.e] 서랍 속에 간직해 둔 편지들, 이제 디어리에 보관해요 📮
+아래 링크로 1초 만에 가입하고, 소중한 추억을 차곡차곡 쌓아볼까요?`;
+
+export function buildInviteShareText(inviteUrl: string) {
+  return `${INVITE_SHARE_MESSAGE}\n${inviteUrl}`;
+}

--- a/src/hooks/queries/inviteKeys.ts
+++ b/src/hooks/queries/inviteKeys.ts
@@ -1,0 +1,3 @@
+export const inviteKeys = {
+  verify: (inviteCode: string) => ['invite', 'verify', inviteCode] as const,
+};

--- a/src/hooks/queries/inviteKeys.ts
+++ b/src/hooks/queries/inviteKeys.ts
@@ -1,4 +1,5 @@
 export const inviteKeys = {
-  link: ['invite', 'link'] as const,
+  // 초대 링크는 계정마다 다르므로 userId를 키에 포함 (계정 전환 시 캐시 혼선 방지)
+  link: (userId?: number) => ['invite', 'link', userId] as const,
   verify: (inviteCode: string) => ['invite', 'verify', inviteCode] as const,
 };

--- a/src/hooks/queries/inviteKeys.ts
+++ b/src/hooks/queries/inviteKeys.ts
@@ -1,3 +1,4 @@
 export const inviteKeys = {
+  link: ['invite', 'link'] as const,
   verify: (inviteCode: string) => ['invite', 'verify', inviteCode] as const,
 };

--- a/src/hooks/queries/useInviteLink.ts
+++ b/src/hooks/queries/useInviteLink.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query';
+import { getInviteLink } from '@/api/invite';
+import { inviteKeys } from '@/hooks/queries/inviteKeys';
+import { useAuthStore } from '@/stores/authStore';
+
+// 시트가 열릴 때 미리 받아 두어야 복사 버튼 클릭 시 await 없이 바로 클립보드에 넣을 수 있음
+export function useInviteLink(enabled: boolean) {
+  const authStatus = useAuthStore((s) => s.authStatus);
+
+  return useQuery({
+    queryKey: inviteKeys.link,
+    queryFn: getInviteLink,
+    enabled: enabled && authStatus === 'authenticated',
+    // 서버가 사용자당 코드를 재사용 -> 다시 받기 X
+    staleTime: Infinity,
+    refetchOnWindowFocus: false,
+  });
+}

--- a/src/hooks/queries/useInviteLink.ts
+++ b/src/hooks/queries/useInviteLink.ts
@@ -1,17 +1,22 @@
 import { useQuery } from '@tanstack/react-query';
 import { getInviteLink } from '@/api/invite';
 import { inviteKeys } from '@/hooks/queries/inviteKeys';
+import { useMeQuery } from '@/hooks/queries/useMeQuery';
 import { useAuthStore } from '@/stores/authStore';
 
 // 시트가 열릴 때 미리 받아 두어야 복사 버튼 클릭 시 await 없이 바로 클립보드에 넣을 수 있음
 export function useInviteLink(enabled: boolean) {
   const authStatus = useAuthStore((s) => s.authStatus);
 
+  // staleTime이 Infinity라 계정이 바뀌어도 캐시가 남을 수 있으므로 userId로 키를 분리
+  const { data: me } = useMeQuery();
+  const userId = me?.userId;
+
   return useQuery({
-    queryKey: inviteKeys.link,
+    queryKey: inviteKeys.link(userId),
     queryFn: getInviteLink,
-    enabled: enabled && authStatus === 'authenticated',
-    // 서버가 사용자당 코드를 재사용 -> 다시 받기 X
+    enabled: enabled && authStatus === 'authenticated' && userId !== undefined,
+    // 서버가 사용자당 코드를 재사용
     staleTime: Infinity,
     refetchOnWindowFocus: false,
   });

--- a/src/hooks/queries/useInviteVerify.ts
+++ b/src/hooks/queries/useInviteVerify.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
+import { getInviteVerify } from '@/api/invite';
+import { inviteKeys } from '@/hooks/queries/inviteKeys';
+
+export function useInviteVerify(inviteCode: string | undefined) {
+  return useQuery({
+    queryKey: inviteKeys.verify(inviteCode ?? ''),
+    queryFn: () => getInviteVerify(inviteCode as string),
+    enabled: !!inviteCode,
+    // 유효하지 않은 코드 -> 재시도 X
+    retry: false,
+    staleTime: Infinity,
+    refetchOnWindowFocus: false,
+  });
+}

--- a/src/hooks/useInviteLinkCopy.ts
+++ b/src/hooks/useInviteLinkCopy.ts
@@ -1,0 +1,25 @@
+// 초대 링크 복사
+
+import { useInviteLink } from '@/hooks/queries/useInviteLink';
+import { buildInviteShareText } from '@/constants/invite';
+import { copyToClipboard } from '@/utils/clipboard';
+import useToast from '@/hooks/useToast';
+
+// 초대 시트가 열려 있는지
+export function useInviteLinkCopy(enabled: boolean) {
+  const toast = useToast();
+  const { data: inviteLink, refetch: refetchInviteLink } = useInviteLink(enabled);
+
+  return async () => {
+    // 시트 열릴 때 미리 받아 둔 링크를 우선 사용, 아직 없으면 이 시점에 요청
+    const url = inviteLink?.inviteUrl ?? (await refetchInviteLink()).data?.inviteUrl;
+
+    if (!url) {
+      toast.show('초대 링크를 불러오지 못했어요. 잠시 후 다시 시도해 주세요.');
+      return;
+    }
+
+    const copied = await copyToClipboard(buildInviteShareText(url));
+    toast.show(copied ? '초대 링크를 복사했어요' : '초대 링크 복사에 실패했어요');
+  };
+}

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -43,6 +43,14 @@ const fitToMaxSide = (w: number, h: number, maxSide: number) => {
 
 const cloneStickers = (arr: StickerItem[]) => arr.map((s) => ({ ...s }));
 
+// 변경 여부 비교용
+const stickerSignature = (arr: StickerItem[]) =>
+  JSON.stringify(
+    arr
+      .map((s) => [s.id, s.imageId, s.x, s.y, s.z, s.rotation, s.scale])
+      .sort((a, b) => Number(a[0]) - Number(b[0]))
+  );
+
 export default function HomePage() {
   const navigate = useNavigate();
   const { homeBgColor, setHomeBgColor } = useOutletContext<AppLayoutContext>();
@@ -247,7 +255,24 @@ export default function HomePage() {
     setBgColorBackup(null);
   };
 
+  const closeEditor = () => {
+    setOpenSheet(false);
+    setSelectedId(null);
+    setPickerOpen(false);
+    setShowResetSheet(false);
+    setBgColorBackup(null);
+  };
+
   const handleCompleteCustomizing = async () => {
+    const bgChanged = bgColorBackup !== null && homeBgColor !== bgColorBackup;
+    const stickersChanged = stickerSignature(draftStickers) !== stickerSignature(baseStickers);
+
+    // 변경 사항 없으면 저장, 바텀 시트 X
+    if (!bgChanged && !stickersChanged) {
+      closeEditor();
+      return;
+    }
+
     // 잠금 해제 전에는 저장할 수 없음
     // 편집 상태를 그대로 둔 채 초대 시트만 띄움 -> 변경 사항은 저장 X
     if (!isUnlocked) {
@@ -259,11 +284,7 @@ export default function HomePage() {
     const saved = draftStickers.filter((s) => s.imageId !== null && s.imageId !== undefined);
     const droppedCount = draftStickers.length - saved.length;
 
-    setOpenSheet(false);
-    setSelectedId(null);
-    setPickerOpen(false);
-    setShowResetSheet(false);
-    setBgColorBackup(null);
+    closeEditor();
 
     try {
       if (droppedCount > 0) {

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -22,6 +22,9 @@ import { useUnpinLetter } from '@/hooks/mutations/useUnpinLetter';
 import useToast from '@/hooks/useToast';
 import closeIcon from '@/assets/homePage/closeIcon.svg';
 import PwaRecommendSheet from '@/components/pwa/PwaRecommendSheet';
+import { useInviteLink } from '@/hooks/queries/useInviteLink';
+import { buildInviteShareText } from '@/constants/invite';
+import { copyToClipboard } from '@/utils/clipboard';
 
 const loadImageSize = (src: string) =>
   new Promise<{ w: number; h: number }>((resolve, reject) => {
@@ -100,6 +103,9 @@ export default function HomePage() {
   const [confirmCloseOpen, setConfirmCloseOpen] = useState(false);
   const [showResetSheet, setShowResetSheet] = useState(false);
   const [showInviteSheet, setShowInviteSheet] = useState(false);
+
+  // 시트가 열릴 때 미리 초대 링크를 받아 둠 (복사 시 지연/실패 방지)
+  const { data: inviteLink, refetch: refetchInviteLink } = useInviteLink(showInviteSheet);
 
   const containerRef = useRef<HTMLDivElement | null>(null);
   // 스티커 이동 범위 제한
@@ -272,6 +278,22 @@ export default function HomePage() {
   };
 
   const toast = useToast();
+
+  // 초대 링크 복사
+  const handleCopyInviteLink = async () => {
+    // 시트 열릴 때 미리 받아 둔 링크를 우선 사용, 아직 없으면 이 시점에 요청
+    const url = inviteLink?.inviteUrl ?? (await refetchInviteLink()).data?.inviteUrl;
+
+    if (!url) {
+      toast.show('초대 링크를 불러오지 못했어요. 잠시 후 다시 시도해 주세요.');
+      return;
+    }
+
+    const copied = await copyToClipboard(buildInviteShareText(url));
+
+    setShowInviteSheet(false);
+    toast.show(copied ? '초대 링크를 복사했어요' : '초대 링크 복사에 실패했어요');
+  };
 
   const addStickerFromFile = async (file: File) => {
     const rect = containerRef.current?.getBoundingClientRect();
@@ -477,10 +499,7 @@ export default function HomePage() {
       <FriendInviteSheet
         open={showInviteSheet}
         onClose={() => setShowInviteSheet(false)}
-        onInvite={() => {
-          // 초대 링크 API 연동 후 클립보드 복사 처리
-          setShowInviteSheet(false);
-        }}
+        onInvite={handleCopyInviteLink}
       />
       <LetterCard
         letter={letter}

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -1,6 +1,6 @@
 // 홈 화면
 import { useMemo, useRef, useState, useEffect } from 'react';
-import { useOutletContext, useNavigate } from 'react-router-dom';
+import { useOutletContext, useNavigate, useLocation } from 'react-router-dom';
 import type { AppLayoutContext } from '@/layouts/AppLayout';
 import ProfileCard from '@/components/home/ProfileCard';
 import ProfileSettingSheet from '@/components/home/ProfileSettingSheet';
@@ -10,6 +10,7 @@ import AddLetterButton from '@/components/home/AddLetterButton';
 import ProfileCustomSheet from '@/components/home/ProfileCustomSheet';
 import CustomResetSheet from '@/components/home/CustomResetSheet';
 import FriendInviteSheet from '@/components/common/FriendInviteSheet';
+import InviteWelcomeSheet from '@/components/common/InviteWelcomeSheet';
 import CustomizingHeader from '@/components/header/CustomizingHeader';
 import StickerLayer, { type StickerItem } from '@/components/home/StickerLayer';
 import { uploadImage } from '@/api/upload';
@@ -106,6 +107,18 @@ export default function HomePage() {
 
   // 시트가 열릴 때 미리 초대 링크를 받아 둠 (복사 시 지연/실패 방지)
   const { data: inviteLink, refetch: refetchInviteLink } = useInviteLink(showInviteSheet);
+
+  // 초대 링크로 가입 완료 -> 환영 시트 노출
+  const location = useLocation();
+  const [showInviteWelcome, setShowInviteWelcome] = useState(
+    () => !!(location.state as { invitedSignup?: boolean } | null)?.invitedSignup
+  );
+
+  useEffect(() => {
+    if (!showInviteWelcome) return;
+    // 새로고침, 뒤로가기로 다시 뜨지 않도록 라우터 state 소비 후 제거
+    navigate('.', { replace: true, state: null });
+  }, [showInviteWelcome, navigate]);
 
   const containerRef = useRef<HTMLDivElement | null>(null);
   // 스티커 이동 범위 제한
@@ -500,6 +513,14 @@ export default function HomePage() {
         open={showInviteSheet}
         onClose={() => setShowInviteSheet(false)}
         onInvite={handleCopyInviteLink}
+      />
+      <InviteWelcomeSheet
+        open={showInviteWelcome}
+        onClose={() => setShowInviteWelcome(false)}
+        onGoCustomize={() => {
+          setShowInviteWelcome(false);
+          openEditor();
+        }}
       />
       <LetterCard
         letter={letter}

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -23,9 +23,8 @@ import { useUnpinLetter } from '@/hooks/mutations/useUnpinLetter';
 import useToast from '@/hooks/useToast';
 import closeIcon from '@/assets/homePage/closeIcon.svg';
 import PwaRecommendSheet from '@/components/pwa/PwaRecommendSheet';
-import { useInviteLink } from '@/hooks/queries/useInviteLink';
-import { buildInviteShareText } from '@/constants/invite';
-import { copyToClipboard } from '@/utils/clipboard';
+import { useInviteLinkCopy } from '@/hooks/useInviteLinkCopy';
+import { useMyMembership } from '@/hooks/queries/useMyMembership';
 
 const loadImageSize = (src: string) =>
   new Promise<{ w: number; h: number }>((resolve, reject) => {
@@ -106,7 +105,11 @@ export default function HomePage() {
   const [showInviteSheet, setShowInviteSheet] = useState(false);
 
   // 시트가 열릴 때 미리 초대 링크를 받아 둠 (복사 시 지연/실패 방지)
-  const { data: inviteLink, refetch: refetchInviteLink } = useInviteLink(showInviteSheet);
+  const copyInviteLink = useInviteLinkCopy(showInviteSheet);
+
+  // 잠금 해제 여부
+  const { data: membership } = useMyMembership();
+  const isUnlocked = !!membership?.isPlus;
 
   // 초대 링크로 가입 완료 -> 환영 시트 노출
   const location = useLocation();
@@ -245,6 +248,13 @@ export default function HomePage() {
   };
 
   const handleCompleteCustomizing = async () => {
+    // 잠금 해제 전에는 저장할 수 없음
+    // 편집 상태를 그대로 둔 채 초대 시트만 띄움 -> 변경 사항은 저장 X
+    if (!isUnlocked) {
+      setShowInviteSheet(true);
+      return;
+    }
+
     // 통합 API가 스티커 전체를 덮어쓰므로 추가/수정/삭제를 구분하지 않고 draft를 그대로 전송
     const saved = draftStickers.filter((s) => s.imageId !== null && s.imageId !== undefined);
     const droppedCount = draftStickers.length - saved.length;
@@ -282,9 +292,6 @@ export default function HomePage() {
           scale: s.scale,
         })),
       });
-
-      // 초대 여부 API 연동 후 아직 친구를 초대하지 않은 사용자에게만 노출
-      setShowInviteSheet(true);
     } catch (e) {
       console.error(e);
     }
@@ -294,18 +301,8 @@ export default function HomePage() {
 
   // 초대 링크 복사
   const handleCopyInviteLink = async () => {
-    // 시트 열릴 때 미리 받아 둔 링크를 우선 사용, 아직 없으면 이 시점에 요청
-    const url = inviteLink?.inviteUrl ?? (await refetchInviteLink()).data?.inviteUrl;
-
-    if (!url) {
-      toast.show('초대 링크를 불러오지 못했어요. 잠시 후 다시 시도해 주세요.');
-      return;
-    }
-
-    const copied = await copyToClipboard(buildInviteShareText(url));
-
+    await copyInviteLink();
     setShowInviteSheet(false);
-    toast.show(copied ? '초대 링크를 복사했어요' : '초대 링크 복사에 실패했어요');
   };
 
   const addStickerFromFile = async (file: File) => {

--- a/src/pages/invite/InviteEntryPage.tsx
+++ b/src/pages/invite/InviteEntryPage.tsx
@@ -1,0 +1,39 @@
+// 초대 링크로 진입했을 때 코드를 검증하는 페이지
+// 유효하면 초대 코드를 보관하고 소셜 로그인 화면으로 이동, 유효하지 않으면 안내 페이지로 이동
+
+import { useEffect } from 'react';
+import { Navigate, useNavigate, useParams } from 'react-router-dom';
+import { useAuthStore } from '@/stores/authStore';
+import { useInviteVerify } from '@/hooks/queries/useInviteVerify';
+import { savePendingInviteCode } from '@/utils/inviteCode';
+
+export default function InviteEntryPage() {
+  const navigate = useNavigate();
+  const { inviteCode } = useParams();
+  const authStatus = useAuthStore((s) => s.authStatus);
+
+  const { data, isError } = useInviteVerify(inviteCode);
+
+  useEffect(() => {
+    if (!data) return;
+    savePendingInviteCode(data.inviteCode);
+    navigate('/login', { replace: true });
+  }, [data, navigate]);
+
+  useEffect(() => {
+    if (isError) {
+      navigate('/invite/invalid', { replace: true });
+    }
+  }, [isError, navigate]);
+
+  // 이미 가입된 사용자는 초대 혜택 대상이 아님
+  if (authStatus === 'authenticated') {
+    return <Navigate to="/" replace />;
+  }
+
+  return (
+    <div className="flex flex-1 items-center justify-center text-[14px] font-medium text-[#737478]">
+      초대 링크 확인 중...
+    </div>
+  );
+}

--- a/src/pages/my/StylePage.tsx
+++ b/src/pages/my/StylePage.tsx
@@ -8,11 +8,19 @@ import { FONT_OPTIONS } from '@/utils/fontOptions';
 import { useStyleStore } from '@/stores/styleStores';
 import { BottomButton } from '@/components/common/BottomButton';
 import { patchMyFont, serverFontToClient } from '@/api/theme';
+import FriendInviteSheet from '@/components/common/FriendInviteSheet';
+import { useMyMembership } from '@/hooks/queries/useMyMembership';
+import { useInviteLinkCopy } from '@/hooks/useInviteLinkCopy';
 
 export default function StylePage() {
   const navigate = useNavigate();
 
-  // const isPlus = true;
+  // 잠금 해제 여부 (초대 성공 시 서버가 isPlus를 켜 줌)
+  const { data: membership } = useMyMembership();
+  const isUnlocked = !!membership?.isPlus;
+
+  const [showInviteSheet, setShowInviteSheet] = useState(false);
+  const copyInviteLink = useInviteLinkCopy(showInviteSheet);
 
   const font = useStyleStore((s) => s.font);
   const setFont = useStyleStore((s) => s.setFont);
@@ -35,10 +43,16 @@ export default function StylePage() {
   const onSubmit = useCallback(async () => {
     if (pendingFont === font) return;
 
+    // 잠금 해제 전에는 저장할 수 없음 (선택 상태는 유지한 채 초대 시트만 노출)
+    if (!isUnlocked) {
+      setShowInviteSheet(true);
+      return;
+    }
+
     const res = await patchMyFont(pendingFont);
     setFont(serverFontToClient(res.font));
     navigate(-1);
-  }, [pendingFont, font, setFont, navigate]);
+  }, [pendingFont, font, isUnlocked, setFont, navigate]);
 
   useEffect(() => {
     if (!setFixedAction) return;
@@ -100,6 +114,15 @@ export default function StylePage() {
           })}
         </div>
       </div>
+
+      <FriendInviteSheet
+        open={showInviteSheet}
+        onClose={() => setShowInviteSheet(false)}
+        onInvite={async () => {
+          await copyInviteLink();
+          setShowInviteSheet(false);
+        }}
+      />
     </div>
   );
 }

--- a/src/pages/onboarding/LoginPage.tsx
+++ b/src/pages/onboarding/LoginPage.tsx
@@ -4,6 +4,7 @@ import PageAI from '@/components/onboarding/PageAI';
 import PageArchive from '@/components/onboarding/PageArchive';
 import { SocialLoginButton } from '@/components/common/SocialLoginButton';
 import { getOAuthAuthorizeUrl } from '@/api/auth';
+import { readPendingInviteCode } from '@/utils/inviteCode';
 
 export default function LoginPage() {
   const [pageIdx, setPageIdx] = useState(0);
@@ -58,15 +59,15 @@ export default function LoginPage() {
     [activeIdx]
   );
 
-  const onKakaoLogin = async () => {
-    const url = await getOAuthAuthorizeUrl('kakao');
+  // 초대 링크로 진입했다면 보관해 둔 코드를 authorize 요청에 실어 보냄
+  const startOAuth = async (provider: 'kakao' | 'google') => {
+    const inviteCode = readPendingInviteCode() ?? undefined;
+    const url = await getOAuthAuthorizeUrl(provider, inviteCode);
     window.location.href = url;
   };
 
-  const onGoogleLogin = async () => {
-    const url = await getOAuthAuthorizeUrl('google');
-    window.location.href = url;
-  };
+  const onKakaoLogin = () => startOAuth('kakao');
+  const onGoogleLogin = () => startOAuth('google');
 
   return (
     <div className="w-full max-w-[440px] mx-auto flex flex-col min-w-0">

--- a/src/pages/onboarding/OAuthCallbackPage.tsx
+++ b/src/pages/onboarding/OAuthCallbackPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react';
 import { useNavigate, useSearchParams, useParams } from 'react-router-dom';
 import { useAuthStore } from '@/stores/authStore';
 import { api } from '@/api/http';
+import { clearPendingInviteCode } from '@/utils/inviteCode';
 
 type ResultType = 'SIGNUP_REQUIRED' | 'REGISTERED';
 
@@ -40,6 +41,8 @@ export default function OAuthCallbackPage() {
       }
 
       if (resultType === 'REGISTERED') {
+        // 기존 회원은 초대 혜택 대상이 아니므로 보관 중인 코드를 정리
+        clearPendingInviteCode();
         setAuthStatus('authenticated');
         navigate('/', { replace: true });
         return;

--- a/src/pages/setup/SetNicknamePage.tsx
+++ b/src/pages/setup/SetNicknamePage.tsx
@@ -5,6 +5,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { BottomButton } from '@/components/common/BottomButton';
 import { postSignup, postJwtRefresh } from '@/api/authSignup';
 import { useAuthStore } from '@/stores/authStore';
+import { clearPendingInviteCode, readPendingInviteCode } from '@/utils/inviteCode';
 
 const NICKNAME_REGEX = /^[A-Za-z0-9가-힣ㄱ-ㅎㅏ-ㅣ ]+$/;
 
@@ -72,8 +73,12 @@ const SetNamePage = () => {
       setAuthStatus('authenticated'); // 가입 완료 -> 인증 상태로 업데이트 -> 다시 terms로 안 가고 home으로
       // console.log("[Signup] /auth/jwt/refresh success:", refreshRes);
 
+      // 초대 링크를 타고 들어와 가입한 경우 홈에서 환영 시트를 띄움
+      const invitedSignup = !!readPendingInviteCode();
+      clearPendingInviteCode();
+
       // console.log("[Signup] signup flow completed");
-      navigate('/', { replace: true });
+      navigate('/', { replace: true, state: invitedSignup ? { invitedSignup: true } : null });
     } catch (e) {
       console.error(e);
       navigate('/login', { replace: true });

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -33,6 +33,7 @@ import EditLetterPage from '@/pages/letter/EditLetterPage';
 import AuthGuard from '@/routes/AuthGuard';
 import LetterSelectPage from '@/pages/letter/LetterSelectPage';
 import InvalidInvitePage from '@/pages/invite/InvalidInvitePage';
+import InviteEntryPage from '@/pages/invite/InviteEntryPage';
 import InviteWelcomeSheet from '@/components/common/InviteWelcomeSheet';
 
 const router = createBrowserRouter([
@@ -49,6 +50,7 @@ const router = createBrowserRouter([
 
           // 초대 링크
           { path: 'invite/invalid', element: <InvalidInvitePage /> },
+          { path: 'invite/:inviteCode', element: <InviteEntryPage /> },
           // 초대 가입 환영 시트 확인용 - 임시
           {
             path: 'invite/welcome-preview',

--- a/src/types/invite.ts
+++ b/src/types/invite.ts
@@ -1,0 +1,12 @@
+// 초대 링크 타입
+
+// 내 초대 코드 및 링크 발급
+export interface InviteLink {
+  inviteCode: string;
+  inviteUrl: string;
+}
+
+// 초대 코드 유효성 검증
+export interface InviteVerify {
+  inviteCode: string;
+}

--- a/src/utils/clipboard.ts
+++ b/src/utils/clipboard.ts
@@ -1,0 +1,31 @@
+// 클립보드 복사
+
+export async function copyToClipboard(text: string): Promise<boolean> {
+  try {
+    if (navigator.clipboard && window.isSecureContext) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    // fallback으로 넘어감
+  }
+
+  try {
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.setAttribute('readonly', '');
+    textarea.style.position = 'fixed';
+    textarea.style.top = '-9999px';
+    document.body.appendChild(textarea);
+
+    textarea.select();
+    textarea.setSelectionRange(0, textarea.value.length);
+
+    const ok = document.execCommand('copy');
+    document.body.removeChild(textarea);
+
+    return ok;
+  } catch {
+    return false;
+  }
+}

--- a/src/utils/inviteCode.ts
+++ b/src/utils/inviteCode.ts
@@ -1,0 +1,50 @@
+// 초대 링크로 진입한 코드를 소셜 로그인이 시작될 때까지 임시 보관
+// 링크만 열고 가입은 안 한 사람의 코드를 언제까지 localStorage에 들고 있을지
+
+const KEY = 'deare-invite-code';
+const TTL = 1000 * 60 * 60 * 24; // 24시간
+
+type StoredInviteCode = {
+  code: string;
+  savedAt: number;
+};
+
+export function savePendingInviteCode(code: string) {
+  try {
+    const payload: StoredInviteCode = { code, savedAt: Date.now() };
+    localStorage.setItem(KEY, JSON.stringify(payload));
+  } catch {
+    // localStorage 접근 불가 시 무시
+  }
+}
+
+export function readPendingInviteCode(): string | null {
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (!raw) return null;
+
+    const parsed = JSON.parse(raw) as Partial<StoredInviteCode>;
+    if (!parsed?.code || typeof parsed.savedAt !== 'number') {
+      clearPendingInviteCode();
+      return null;
+    }
+
+    // 오래된 코드가 남아 나중의 가입에 잘못 붙는 걸 방지
+    if (Date.now() - parsed.savedAt > TTL) {
+      clearPendingInviteCode();
+      return null;
+    }
+
+    return parsed.code;
+  } catch {
+    return null;
+  }
+}
+
+export function clearPendingInviteCode() {
+  try {
+    localStorage.removeItem(KEY);
+  } catch {
+    // 무시
+  }
+}


### PR DESCRIPTION
## #️⃣ 관련 이슈
- close #239

---

## 📝 작업 요약
초대 링크 발급/검증부터 잠금 해제까지 초대 기능 전체 연동

---

## 🔧 변경 사항
**초대 링크 API 연동**
- `GET /invites/code` 발급, `GET /invites/{code}/validate` 검증
- 검증 API는 비로그인 진입이므로 `publicApi` 사용

**초대 링크 진입 플로우**
- `/invite/:inviteCode` 라우트 추가, 진입 시 코드 검증
- 유효하지 않으면 `/invite/invalid`로 이동
- 이미 로그인된 사용자는 홈으로 이동

**초대 코드 전달**
- 소셜 로그인 authorize 요청에 `inviteCode` 쿼리 파라미터 추가
- 리다이렉트 왕복 동안 코드 유지를 위한 임시 보관 유틸 추가
- 가입 완료 / 기존 회원 확인 시점에 코드 정리, 미사용 시 24시간 후 만료

**초대 링크 복사**
- `링크 복사하기` 클릭 시 안내 문구와 링크를 함께 복사
- 시트 오픈 시점에 링크를 선조회 (iOS 사파리 클립보드 제약 대응)
- 양방향 잠금 해제 로직에 맞춰 바텀시트 문구 수정

**초대 가입 환영 시트**
- 초대 링크로 가입 완료 시 홈에서 1회 노출
- `홈 화면 꾸미러 가기` 클릭 시 홈 편집 모드 진입

**꾸미기 기능 잠금**
- 잠금 해제 전 배경색·스티커·폰트 저장 시도 시 친구 초대 시트 노출
- 저장은 수행하지 않고 편집 상태 유지
- 변경 사항이 없으면 시트 노출 및 저장 요청 생략


---

## 💬 리뷰어 참고 사항
리뷰 시 참고하면 좋을 점이나 고민했던 부분이 있다면 작성해주세요.

---

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [x] 로컬에서 정상 동작을 확인했습니다.
- [x] UI 변경 사항을 직접 확인했습니다.
- [x] 불필요한 console.log를 제거했습니다.
- [x] 관련 이슈를 연결했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 초대 링크를 생성하고 복사할 수 있습니다.
  * 초대 링크의 유효성을 확인한 뒤 가입을 진행할 수 있습니다.
  * 초대 가입 완료 후 환영 안내와 홈 꾸미기 기능을 이용할 수 있습니다.
  * 초대 코드가 소셜 로그인 과정에 자동으로 연결됩니다.
  * 초대 조건에 따라 꾸미기 기능 잠금이 해제됩니다.

* **개선**
  * 초대 링크 공유 문구와 혜택 안내를 개선했습니다.
  * 초대 링크 복사 성공 및 실패 결과를 안내합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->